### PR TITLE
Issue #130: Per-room heating-only mode (bathroom electric heater)

### DIFF
--- a/pumpahead/building_profiles.py
+++ b/pumpahead/building_profiles.py
@@ -35,6 +35,7 @@ __all__ = [
     "MODERN_BUNGALOW_ROOMS",
     "heavy_construction",
     "modern_bungalow",
+    "modern_bungalow_with_bathroom_heater",
     "modern_bungalow_with_splits",
     "leaky_old_house",
     "thin_screed",
@@ -419,6 +420,97 @@ def modern_bungalow_with_splits() -> BuildingParams:
 
 
 # ---------------------------------------------------------------------------
+# modern_bungalow_with_bathroom_heater — heating-only electric heater variant
+# ---------------------------------------------------------------------------
+#
+# The real bathroom (lazienka) has a 300 W electric towel rail / resistive
+# heater intended to cover peak heating demand when UFH alone is too slow
+# to track the 24 °C setpoint against the 20 °C house-wide target.  This
+# profile mirrors the real wiring: only ``lazienka`` is modified, gaining a
+# ``has_split=True`` auxiliary that is actually a heating-only source
+# (``auxiliary_type="heater"``, ``ufh_cooling_max_power_w=0.0``).  All other
+# rooms are identical to ``modern_bungalow``.
+
+
+_BATHROOM_HEATER_POWER_W = 300.0
+
+
+def _lazienka_with_heater(room: RoomConfig) -> RoomConfig:
+    """Return a copy of ``room`` with a 300 W heating-only heater.
+
+    Only the ``lazienka`` room is modified.  The new RoomConfig has
+    ``has_split=True`` (to reuse the SplitCoordinator pipeline),
+    ``split_power_w=300.0`` W, ``auxiliary_type="heater"`` and
+    ``ufh_cooling_max_power_w=0.0`` (heater rooms must not cool).
+    The underlying ``RCParams`` is rebuilt with ``has_split=True``.
+
+    Args:
+        room: Source room configuration.
+
+    Returns:
+        Modified ``RoomConfig`` when ``room.name == "lazienka"``,
+        otherwise returns the input unchanged.
+    """
+    if room.name != "lazienka":
+        return room
+    p = room.params
+    params_with_split = RCParams(
+        C_air=p.C_air,
+        C_slab=p.C_slab,
+        C_wall=p.C_wall,
+        R_sf=p.R_sf,
+        R_wi=p.R_wi,
+        R_wo=p.R_wo,
+        R_ve=p.R_ve,
+        R_ins=p.R_ins,
+        f_conv=p.f_conv,
+        f_rad=p.f_rad,
+        T_ground=p.T_ground,
+        has_split=True,
+    )
+    return RoomConfig(
+        name=room.name,
+        area_m2=room.area_m2,
+        params=params_with_split,
+        windows=room.windows,
+        has_split=True,
+        split_power_w=_BATHROOM_HEATER_POWER_W,
+        ufh_max_power_w=room.ufh_max_power_w,
+        ufh_cooling_max_power_w=0.0,
+        ufh_loops=room.ufh_loops,
+        q_int_w=room.q_int_w,
+        auxiliary_type="heater",
+    )
+
+
+def modern_bungalow_with_bathroom_heater() -> BuildingParams:
+    """Modern bungalow variant with a 300 W electric heater in the bathroom.
+
+    Identical thermal envelope to ``modern_bungalow``, except that
+    ``lazienka`` gains a heating-only electric resistive heater
+    (``auxiliary_type="heater"``, 300 W).  The heater reuses the
+    ``SplitCoordinator`` pipeline but the controller forces
+    ``SplitMode.OFF`` for heater rooms in cooling mode so the heater
+    never opposes the HP mode (Axiom #3).  Bathroom floor cooling is
+    disabled (``ufh_cooling_max_power_w=0.0``) consistent with the
+    real wiring.
+
+    All other 12 rooms are identical to ``modern_bungalow``.
+
+    Returns:
+        Validated ``BuildingParams`` with 13 rooms (lazienka with
+        heating-only heater, all others UFH-only).
+    """
+    rooms = tuple(_lazienka_with_heater(r) for r in MODERN_BUNGALOW_ROOMS)
+    return BuildingParams(
+        rooms=rooms,
+        hp_max_power_w=_BUNGALOW_HP_MAX_W,
+        latitude=_BUNGALOW_LAT,
+        longitude=_BUNGALOW_LON,
+    )
+
+
+# ---------------------------------------------------------------------------
 # well_insulated — modern passive-house-like single room
 # ---------------------------------------------------------------------------
 
@@ -624,6 +716,7 @@ def heavy_construction() -> BuildingParams:
 BUILDING_PROFILES: dict[str, Callable[[], BuildingParams]] = {
     "modern_bungalow": modern_bungalow,
     "modern_bungalow_with_splits": modern_bungalow_with_splits,
+    "modern_bungalow_with_bathroom_heater": modern_bungalow_with_bathroom_heater,
     "well_insulated": well_insulated,
     "leaky_old_house": leaky_old_house,
     "thin_screed": thin_screed,

--- a/pumpahead/config.py
+++ b/pumpahead/config.py
@@ -19,7 +19,7 @@ Units:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
 from pumpahead.model import RCParams
@@ -90,6 +90,16 @@ class RoomConfig:
             cooling capability).
         ufh_loops: Number of UFH loops (must be >= 1).
         q_int_w: Internal heat gains [W] (must be >= 0).
+        auxiliary_type: Type of the auxiliary heat source.  ``"split"``
+            (default) models a reversible split/AC unit that can heat
+            or cool depending on the HP mode.  ``"heater"`` models a
+            heating-only source (e.g. an electric resistive heater) and
+            is only active in heating mode — the controller forces
+            ``SplitMode.OFF`` in cooling mode regardless of error.
+            ``"heater"`` requires ``has_split=True`` (to reuse the
+            ``SplitCoordinator`` pipeline) and
+            ``ufh_cooling_max_power_w == 0.0`` (heater rooms must not
+            cool via the floor either).
     """
 
     name: str
@@ -102,6 +112,7 @@ class RoomConfig:
     ufh_cooling_max_power_w: float = 0.0
     ufh_loops: int = 1
     q_int_w: float = 0.0
+    auxiliary_type: Literal["split", "heater"] = "split"
 
     def __post_init__(self) -> None:
         """Validate room configuration.
@@ -147,6 +158,27 @@ class RoomConfig:
                 f"RCParams.has_split ({self.params.has_split})"
             )
             raise ValueError(msg)
+        allowed_aux = ("split", "heater")
+        if self.auxiliary_type not in allowed_aux:
+            msg = (
+                f"auxiliary_type must be one of {allowed_aux}, "
+                f"got '{self.auxiliary_type}'"
+            )
+            raise ValueError(msg)
+        if self.auxiliary_type == "heater":
+            if not self.has_split:
+                msg = (
+                    "auxiliary_type='heater' requires has_split=True "
+                    "(heater rooms reuse the split coordinator pipeline)"
+                )
+                raise ValueError(msg)
+            if self.ufh_cooling_max_power_w != 0.0:
+                msg = (
+                    f"auxiliary_type='heater' requires "
+                    f"ufh_cooling_max_power_w=0.0, "
+                    f"got {self.ufh_cooling_max_power_w}"
+                )
+                raise ValueError(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -374,6 +406,10 @@ class SimScenario:
         cwu_schedule: CWU interrupt schedule entries.
         sensor_noise_std: Sensor noise standard deviation [K] (must be >= 0).
         description: Human-readable description for reporting (default "").
+        room_overrides: Optional per-room ``ControllerConfig`` overrides.
+            Keys must match room names in ``building.rooms``.  Rooms not
+            listed use the scenario-level ``controller`` configuration.
+            Empty dict by default.
     """
 
     name: str
@@ -386,6 +422,7 @@ class SimScenario:
     cwu_schedule: tuple[CWUCycle, ...] = ()
     sensor_noise_std: float = 0.0
     description: str = ""
+    room_overrides: dict[str, ControllerConfig] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Validate scenario parameters.
@@ -411,3 +448,20 @@ class SimScenario:
         if self.mode not in allowed_modes:
             msg = f"mode must be one of {allowed_modes}, got '{self.mode}'"
             raise ValueError(msg)
+        if self.room_overrides:
+            known = {r.name for r in self.building.rooms}
+            unknown = set(self.room_overrides.keys()) - known
+            if unknown:
+                msg = (
+                    f"room_overrides contains unknown room names: "
+                    f"{sorted(unknown)}"
+                )
+                raise ValueError(msg)
+            for room_name, override in self.room_overrides.items():
+                if not isinstance(override, ControllerConfig):
+                    msg = (
+                        f"room_overrides[{room_name!r}] must be a "
+                        f"ControllerConfig, got "
+                        f"{type(override).__name__}"
+                    )
+                    raise ValueError(msg)

--- a/pumpahead/config.py
+++ b/pumpahead/config.py
@@ -452,10 +452,7 @@ class SimScenario:
             known = {r.name for r in self.building.rooms}
             unknown = set(self.room_overrides.keys()) - known
             if unknown:
-                msg = (
-                    f"room_overrides contains unknown room names: "
-                    f"{sorted(unknown)}"
-                )
+                msg = f"room_overrides contains unknown room names: {sorted(unknown)}"
                 raise ValueError(msg)
             for room_name, override in self.room_overrides.items():
                 if not isinstance(override, ControllerConfig):

--- a/pumpahead/controller.py
+++ b/pumpahead/controller.py
@@ -190,6 +190,7 @@ class PumpAheadController:
         *,
         room_overrides: dict[str, ControllerConfig] | None = None,
         room_has_split: dict[str, bool] | None = None,
+        room_auxiliary_type: dict[str, str] | None = None,
         cwu_schedule: tuple[CWUCycle, ...] = (),
         mode: Literal["heating", "cooling", "auto"] = "heating",
     ) -> None:
@@ -205,6 +206,12 @@ class PumpAheadController:
                 When ``None`` (default), all rooms are treated as
                 UFH-only (backward compatible).  When provided, rooms
                 with ``True`` get a ``SplitCoordinator`` instance.
+            room_auxiliary_type: Optional per-room auxiliary type map.
+                Values must be ``"split"`` or ``"heater"``.  Rooms not
+                listed default to ``"split"``.  ``"heater"`` rooms are
+                short-circuited to ``SplitMode.OFF`` in cooling mode
+                so that a heating-only electric resistive heater never
+                opposes the HP mode (Axiom #3).
             cwu_schedule: CWU (DHW) interrupt schedule.  When non-empty,
                 a ``CWUCoordinator`` is created for anti-panic split
                 blocking and pre-charge valve boosting.
@@ -235,6 +242,21 @@ class PumpAheadController:
         self._room_configs: dict[str, ControllerConfig] = {}
         self._pids: dict[str, PIDController] = {}
         self._split_coordinators: dict[str, SplitCoordinator] = {}
+        self._auxiliary_type: dict[str, str] = dict(room_auxiliary_type or {})
+        unknown_aux = set(self._auxiliary_type.keys()) - set(names)
+        if unknown_aux:
+            msg = (
+                f"room_auxiliary_type contains unknown room names: "
+                f"{sorted(unknown_aux)}"
+            )
+            raise ValueError(msg)
+        for room_name, aux_value in self._auxiliary_type.items():
+            if aux_value not in ("split", "heater"):
+                msg = (
+                    f"room_auxiliary_type[{room_name!r}] must be "
+                    f"'split' or 'heater', got {aux_value!r}"
+                )
+                raise ValueError(msg)
         self._step_count: int = 0
         self._mode = mode
 
@@ -400,6 +422,24 @@ class PumpAheadController:
             # Split coordination (only for rooms with a coordinator)
             split_mode = SplitMode.OFF
             split_setpoint = 0.0
+
+            # Heating-only auxiliary (e.g. electric resistive heater):
+            # force OFF in cooling mode.  This guard must run BEFORE
+            # SplitCoordinator.decide() so the runtime window is not
+            # contaminated with spurious samples from a source that
+            # physically cannot cool (Axiom #3).
+            is_heater_room = self._auxiliary_type.get(name) == "heater"
+            if is_heater_room and is_cooling:
+                # Short-circuit: no split decision, no valve_floor_boost,
+                # no runtime sample.  Room is UFH-only in cooling mode
+                # (ufh_cooling_max_power_w=0.0 is enforced upstream by
+                # RoomConfig validation, so valve cooling is also zero).
+                actions[name] = Actions(
+                    valve_position=valve,
+                    split_mode=SplitMode.OFF,
+                    split_setpoint=0.0,
+                )
+                continue
 
             if name in self._split_coordinators:
                 # CWU anti-panic: block split when CWU is active and

--- a/pumpahead/scenarios.py
+++ b/pumpahead/scenarios.py
@@ -34,6 +34,7 @@ from pumpahead.building_profiles import (
     heavy_construction,
     leaky_old_house,
     modern_bungalow,
+    modern_bungalow_with_bathroom_heater,
     modern_bungalow_with_splits,
     thin_screed,
     well_insulated,
@@ -50,6 +51,8 @@ from pumpahead.weather import ChannelProfile, ProfileKind, SyntheticWeather
 __all__ = [
     "PARAMETRIC_SWEEPS",
     "SCENARIO_LIBRARY",
+    "bathroom_heater",
+    "bathroom_heater_cooling",
     "cold_snap",
     "cwu_heavy",
     "cwu_with_splits",
@@ -739,6 +742,129 @@ def spring_transition() -> SimScenario:
 
 
 # ---------------------------------------------------------------------------
+# Bathroom heater (heating-only auxiliary) scenarios
+# ---------------------------------------------------------------------------
+
+
+def bathroom_heater() -> SimScenario:
+    """Bathroom with a 300 W electric heater tracking 24 °C in heating mode.
+
+    Uses ``modern_bungalow_with_bathroom_heater`` — identical envelope to
+    ``modern_bungalow`` but ``lazienka`` gains a heating-only 300 W
+    resistive heater (``auxiliary_type="heater"``).  The rest of the house
+    targets 20 °C while ``lazienka`` gets a per-room override setpoint of
+    24 °C.  Tests:
+
+    * The bathroom reaches its 24 °C setpoint within a comfort band of
+      0.7 °C in the second 24 h.
+    * The heater activates (``split_runtime > 0``) but stays well below
+      the anti-takeover threshold.
+    * No priority inversion, no opposing action, floor temperature safe.
+
+    Returns:
+        ``SimScenario`` with ``modern_bungalow_with_bathroom_heater``
+        building, 48 h heating duration at T_out=-5 °C.
+    """
+    weather = SyntheticWeather.constant(
+        T_out=-5.0,
+        GHI=0.0,
+        wind_speed=1.0,
+        humidity=60.0,
+    )
+    base_controller = ControllerConfig(
+        kp=5.0,
+        ki=0.01,
+        setpoint=20.0,
+        split_deadband=0.5,
+    )
+    bathroom_override = ControllerConfig(
+        kp=5.0,
+        ki=0.01,
+        setpoint=24.0,
+        split_deadband=0.5,
+    )
+    return SimScenario(
+        name="bathroom_heater",
+        building=modern_bungalow_with_bathroom_heater(),
+        weather=weather,
+        controller=base_controller,
+        duration_minutes=2880,
+        mode="heating",
+        dt_seconds=60.0,
+        room_overrides={"lazienka": bathroom_override},
+        description=(
+            "Bathroom with 300 W electric heater tracking 24 C at "
+            "T_out=-5 C. Other rooms at 20 C.  Tests heater activation "
+            "in heating mode and Axiom #3 compliance."
+        ),
+    )
+
+
+def bathroom_heater_cooling() -> SimScenario:
+    """Bathroom heater must be passive in cooling mode.
+
+    Same building as ``bathroom_heater`` but with a hot sinusoidal
+    outdoor profile (T_out baseline 30 °C, amplitude 5 °C, 24 h period)
+    and the system in cooling mode.  The bathroom keeps its 24 °C
+    override setpoint (below the 25 °C house-wide target) so an
+    unconstrained coordinator would try to cool it — but the heater
+    has no cooling capability, so the controller must force
+    ``SplitMode.OFF`` and UFH cooling is disabled
+    (``ufh_cooling_max_power_w=0.0``).  Tests:
+
+    * ``split_mode`` is ``OFF`` at every step for ``lazienka``.
+    * ``assert_no_opposing_action`` passes (heater never cools).
+
+    Returns:
+        ``SimScenario`` with ``modern_bungalow_with_bathroom_heater``
+        building, 48 h cooling duration.
+    """
+    weather = SyntheticWeather(
+        t_out=ChannelProfile(
+            kind=ProfileKind.SINUSOIDAL,
+            baseline=30.0,
+            amplitude=5.0,
+            period_minutes=1440.0,
+        ),
+        ghi=ChannelProfile(
+            kind=ProfileKind.SINUSOIDAL,
+            baseline=300.0,
+            amplitude=300.0,
+            period_minutes=1440.0,
+        ),
+        wind_speed=ChannelProfile(kind=ProfileKind.CONSTANT, baseline=1.0),
+        humidity=ChannelProfile(kind=ProfileKind.CONSTANT, baseline=50.0),
+    )
+    base_controller = ControllerConfig(
+        kp=5.0,
+        ki=0.01,
+        setpoint=25.0,
+        split_deadband=0.5,
+    )
+    bathroom_override = ControllerConfig(
+        kp=5.0,
+        ki=0.01,
+        setpoint=24.0,
+        split_deadband=0.5,
+    )
+    return SimScenario(
+        name="bathroom_heater_cooling",
+        building=modern_bungalow_with_bathroom_heater(),
+        weather=weather,
+        controller=base_controller,
+        duration_minutes=2880,
+        mode="cooling",
+        dt_seconds=60.0,
+        room_overrides={"lazienka": bathroom_override},
+        description=(
+            "Bathroom heater in cooling mode (T_out~30 C).  Tests that "
+            "the controller forces SplitMode.OFF for heater rooms "
+            "regardless of error (Axiom #3)."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Parametric sweep functions
 # ---------------------------------------------------------------------------
 
@@ -858,6 +984,8 @@ SCENARIO_LIBRARY: dict[str, Callable[[], SimScenario]] = {
     "dual_source_cooling_steady": dual_source_cooling_steady,
     "spring_transition": spring_transition,
     "dew_point_stress": dew_point_stress,
+    "bathroom_heater": bathroom_heater,
+    "bathroom_heater_cooling": bathroom_heater_cooling,
 }
 """Mapping of scenario name to factory function (single scenarios)."""
 

--- a/tests/simulation/conftest.py
+++ b/tests/simulation/conftest.py
@@ -174,10 +174,15 @@ def run_scenario() -> Callable[
         # Build PumpAheadController from scenario configuration
         room_names = [r.name for r in scenario.building.rooms]
         room_has_split = {r.name: r.has_split for r in scenario.building.rooms}
+        room_auxiliary_type = {
+            r.name: r.auxiliary_type for r in scenario.building.rooms
+        }
         controller = PumpAheadController(
             scenario.controller,
             room_names,
+            room_overrides=dict(scenario.room_overrides),
             room_has_split=room_has_split,
+            room_auxiliary_type=room_auxiliary_type,
             cwu_schedule=tuple(scenario.cwu_schedule),
             mode=scenario.mode,
         )

--- a/tests/simulation/test_split_scenarios.py
+++ b/tests/simulation/test_split_scenarios.py
@@ -21,6 +21,8 @@ from pumpahead.metrics import (
     assert_no_priority_inversion,
 )
 from pumpahead.scenarios import (
+    bathroom_heater,
+    bathroom_heater_cooling,
     dual_source_cold_snap,
     dual_source_steady_state,
     priority_inversion_stress,
@@ -261,3 +263,165 @@ class TestPriorityInversionStress:
         scenario = priority_inversion_stress()
         log, _ = run_scenario(scenario, None)
         assert_no_opposing_action(log)
+
+
+# ---------------------------------------------------------------------------
+# Bathroom heater (heating-only auxiliary) tests
+# ---------------------------------------------------------------------------
+
+
+_LIVING_ROOMS_20C = [
+    "salon",
+    "kuchnia_jadalnia",
+    "sypialnia",
+    "pokoj_dziecka_1",
+]
+
+
+@pytest.mark.simulation
+class TestBathroomHeater:
+    """Tests for the ``bathroom_heater`` and ``bathroom_heater_cooling``
+    scenarios — heating-only electric heater in the bathroom.
+    """
+
+    def test_bathroom_reaches_24c(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """Bathroom tracks its 24 C override setpoint in the second 24h."""
+        scenario = bathroom_heater()
+        log, _ = run_scenario(scenario, None)
+
+        half = scenario.duration_minutes // 2
+        room_log = log.get_room("lazienka").time_range(
+            half, scenario.duration_minutes
+        )
+        room_cfg = next(r for r in scenario.building.rooms if r.name == "lazienka")
+        metrics = SimMetrics.from_log(
+            room_log,
+            setpoint=24.0,
+            comfort_band=0.7,
+            ufh_max_power_w=room_cfg.ufh_max_power_w,
+            split_power_w=room_cfg.split_power_w,
+        )
+        assert metrics.comfort_pct > 80.0, (
+            f"lazienka: comfort_pct={metrics.comfort_pct:.1f}% below 80% "
+            f"(band=0.7, setpoint=24.0)"
+        )
+
+    def test_living_area_reaches_20c(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """Living-area rooms track the 20 C scenario setpoint."""
+        scenario = bathroom_heater()
+        log, _ = run_scenario(scenario, None)
+
+        half = scenario.duration_minutes // 2
+        for room_name in _LIVING_ROOMS_20C:
+            room_log = log.get_room(room_name).time_range(
+                half, scenario.duration_minutes
+            )
+            room_cfg = next(r for r in scenario.building.rooms if r.name == room_name)
+            metrics = SimMetrics.from_log(
+                room_log,
+                setpoint=20.0,
+                comfort_band=1.0,
+                ufh_max_power_w=room_cfg.ufh_max_power_w,
+                split_power_w=room_cfg.split_power_w,
+            )
+            assert metrics.comfort_pct > 80.0, (
+                f"{room_name}: comfort_pct={metrics.comfort_pct:.1f}% "
+                f"below 80% (band=1.0, setpoint=20.0)"
+            )
+
+    def test_heater_activates_in_heating_mode(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """Heater activates (runtime > 0) but stays below 50% (Axiom #2)."""
+        scenario = bathroom_heater()
+        log, _ = run_scenario(scenario, None)
+
+        room_log = log.get_room("lazienka")
+        room_cfg = next(r for r in scenario.building.rooms if r.name == "lazienka")
+        metrics = SimMetrics.from_log(
+            room_log,
+            setpoint=24.0,
+            ufh_max_power_w=room_cfg.ufh_max_power_w,
+            split_power_w=room_cfg.split_power_w,
+        )
+        assert metrics.split_runtime_pct > 0.0, (
+            "heater never activated during heating — expected > 0% "
+            "runtime while tracking 24 C against 20 C house setpoint"
+        )
+        assert metrics.split_runtime_pct < 50.0, (
+            f"heater runtime {metrics.split_runtime_pct:.1f}% exceeds "
+            f"50% — priority inversion"
+        )
+
+    def test_bathroom_passive_in_cooling_mode(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """Bathroom heater is OFF at every step in cooling mode."""
+        scenario = bathroom_heater_cooling()
+        log, _ = run_scenario(scenario, None)
+
+        room_log = log.get_room("lazienka")
+        off_count = 0
+        total = 0
+        for rec in room_log:
+            total += 1
+            if rec.split_mode == SplitMode.OFF:
+                off_count += 1
+        assert off_count == total, (
+            f"lazienka heater activated in cooling mode: "
+            f"{total - off_count}/{total} records had split_mode != OFF"
+        )
+
+    def test_no_opposing_action_across_modes(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """Heater never opposes the HP mode (Axiom #3) in either scenario."""
+        heating_scenario = bathroom_heater()
+        heating_log, _ = run_scenario(heating_scenario, None)
+        assert_no_opposing_action(heating_log)
+
+        cooling_scenario = bathroom_heater_cooling()
+        cooling_log, _ = run_scenario(cooling_scenario, None)
+        assert_no_opposing_action(cooling_log)
+
+    def test_no_priority_inversion_bathroom_heater(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """Heater runtime below 50% (Axiom #2)."""
+        scenario = bathroom_heater()
+        log, _ = run_scenario(scenario, None)
+        room_log = log.get_room("lazienka")
+        assert_no_priority_inversion(room_log, max_split_pct=50.0)
+
+    def test_floor_temp_safe_bathroom_heater(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """Floor temperature stays within safe bounds (Axioms #4, #5)."""
+        scenario = bathroom_heater()
+        log, _ = run_scenario(scenario, None)
+        assert_floor_temp_safe(log)

--- a/tests/simulation/test_split_scenarios.py
+++ b/tests/simulation/test_split_scenarios.py
@@ -295,9 +295,7 @@ class TestBathroomHeater:
         log, _ = run_scenario(scenario, None)
 
         half = scenario.duration_minutes // 2
-        room_log = log.get_room("lazienka").time_range(
-            half, scenario.duration_minutes
-        )
+        room_log = log.get_room("lazienka").time_range(half, scenario.duration_minutes)
         room_cfg = next(r for r in scenario.building.rooms if r.name == "lazienka")
         metrics = SimMetrics.from_log(
             room_log,

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -288,9 +288,7 @@ class TestRoomConfig:
 
     def test_auxiliary_type_heater_with_cooling_raises(self) -> None:
         """``"heater"`` with nonzero cooling power raises ValueError."""
-        with pytest.raises(
-            ValueError, match="requires ufh_cooling_max_power_w=0.0"
-        ):
+        with pytest.raises(ValueError, match="requires ufh_cooling_max_power_w=0.0"):
             RoomConfig(
                 name="bad_room",
                 area_m2=20.0,
@@ -638,9 +636,7 @@ class TestSimScenario:
     def test_room_overrides_valid(self) -> None:
         """Valid room_overrides referencing an existing room is accepted."""
         override = ControllerConfig(setpoint=24.0)
-        scenario = self._make_scenario(
-            room_overrides={"living_room": override}
-        )
+        scenario = self._make_scenario(room_overrides={"living_room": override})
         assert scenario.room_overrides["living_room"].setpoint == 24.0
 
     def test_room_overrides_unknown_room_raises(self) -> None:

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -245,6 +245,62 @@ class TestRoomConfig:
         room = _make_room(q_int_w=150.0)
         assert room.q_int_w == 150.0
 
+    def test_auxiliary_type_default_is_split(self) -> None:
+        """Default auxiliary_type is ``"split"``."""
+        room = _make_room()
+        assert room.auxiliary_type == "split"
+
+    def test_auxiliary_type_heater_valid(self) -> None:
+        """``"heater"`` is accepted when has_split=True and cooling=0.0."""
+        room = RoomConfig(
+            name="lazienka",
+            area_m2=9.0,
+            params=_mimo_params(),
+            has_split=True,
+            split_power_w=300.0,
+            ufh_cooling_max_power_w=0.0,
+            auxiliary_type="heater",
+        )
+        assert room.auxiliary_type == "heater"
+        assert room.has_split is True
+        assert room.ufh_cooling_max_power_w == 0.0
+
+    def test_auxiliary_type_invalid_value_raises(self) -> None:
+        """Unknown auxiliary_type string raises ValueError."""
+        with pytest.raises(ValueError, match="auxiliary_type must be one of"):
+            RoomConfig(
+                name="bad_room",
+                area_m2=20.0,
+                params=_siso_params(),
+                auxiliary_type="turbo",  # type: ignore[arg-type]
+            )
+
+    def test_auxiliary_type_heater_without_split_raises(self) -> None:
+        """``"heater"`` without has_split=True raises ValueError."""
+        with pytest.raises(ValueError, match="requires has_split=True"):
+            RoomConfig(
+                name="bad_room",
+                area_m2=20.0,
+                params=_siso_params(),
+                has_split=False,
+                auxiliary_type="heater",
+            )
+
+    def test_auxiliary_type_heater_with_cooling_raises(self) -> None:
+        """``"heater"`` with nonzero cooling power raises ValueError."""
+        with pytest.raises(
+            ValueError, match="requires ufh_cooling_max_power_w=0.0"
+        ):
+            RoomConfig(
+                name="bad_room",
+                area_m2=20.0,
+                params=_mimo_params(),
+                has_split=True,
+                split_power_w=300.0,
+                ufh_cooling_max_power_w=1000.0,
+                auxiliary_type="heater",
+            )
+
 
 # ===========================================================================
 # TestBuildingParams
@@ -573,3 +629,24 @@ class TestSimScenario:
         """Custom sensor_noise_std is accepted."""
         scenario = self._make_scenario(sensor_noise_std=0.5)
         assert scenario.sensor_noise_std == 0.5
+
+    def test_room_overrides_default_empty(self) -> None:
+        """Default room_overrides is an empty dict."""
+        scenario = self._make_scenario()
+        assert scenario.room_overrides == {}
+
+    def test_room_overrides_valid(self) -> None:
+        """Valid room_overrides referencing an existing room is accepted."""
+        override = ControllerConfig(setpoint=24.0)
+        scenario = self._make_scenario(
+            room_overrides={"living_room": override}
+        )
+        assert scenario.room_overrides["living_room"].setpoint == 24.0
+
+    def test_room_overrides_unknown_room_raises(self) -> None:
+        """Unknown room name in room_overrides raises ValueError."""
+        override = ControllerConfig(setpoint=24.0)
+        with pytest.raises(
+            ValueError, match="room_overrides contains unknown room names"
+        ):
+            self._make_scenario(room_overrides={"ghost_room": override})

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -917,9 +917,7 @@ class TestPumpAheadControllerHeaterAuxiliary:
 
     def test_heater_passive_in_cooling_mode(self) -> None:
         """Heater room is SplitMode.OFF in cooling, split room cools normally."""
-        config = ControllerConfig(
-            kp=5.0, ki=0.0, setpoint=24.0, split_deadband=0.5
-        )
+        config = ControllerConfig(kp=5.0, ki=0.0, setpoint=24.0, split_deadband=0.5)
         ctrl = PumpAheadController(
             config,
             ["heater_room", "split_room"],
@@ -935,9 +933,7 @@ class TestPumpAheadControllerHeaterAuxiliary:
             "heater_room": _make_measurements(
                 t_room=26.0, hp_mode=HeatPumpMode.COOLING
             ),
-            "split_room": _make_measurements(
-                t_room=26.0, hp_mode=HeatPumpMode.COOLING
-            ),
+            "split_room": _make_measurements(t_room=26.0, hp_mode=HeatPumpMode.COOLING),
         }
         actions = ctrl.step(meas)
         # Heater room is passive — no split action.
@@ -948,9 +944,7 @@ class TestPumpAheadControllerHeaterAuxiliary:
 
     def test_heater_activates_in_heating_mode(self) -> None:
         """Heater room activates normally in heating mode (no short-circuit)."""
-        config = ControllerConfig(
-            kp=5.0, ki=0.0, setpoint=24.0, split_deadband=0.5
-        )
+        config = ControllerConfig(kp=5.0, ki=0.0, setpoint=24.0, split_deadband=0.5)
         ctrl = PumpAheadController(
             config,
             ["heater_room"],
@@ -968,9 +962,7 @@ class TestPumpAheadControllerHeaterAuxiliary:
 
     def test_heater_runtime_window_not_contaminated_in_cooling(self) -> None:
         """Cooling-mode short-circuit does not accumulate split runtime."""
-        config = ControllerConfig(
-            kp=5.0, ki=0.0, setpoint=24.0, split_deadband=0.5
-        )
+        config = ControllerConfig(kp=5.0, ki=0.0, setpoint=24.0, split_deadband=0.5)
         ctrl = PumpAheadController(
             config,
             ["heater_room"],

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -904,3 +904,105 @@ class TestPumpAheadControllerCWU:
         # Split runtime should be 0 because split was always blocked
         diag = ctrl.get_diagnostics()
         assert diag["room_a"]["split_runtime_minutes"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# PumpAheadController heating-only auxiliary (heater) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPumpAheadControllerHeaterAuxiliary:
+    """Tests for the ``room_auxiliary_type='heater'`` short-circuit."""
+
+    def test_heater_passive_in_cooling_mode(self) -> None:
+        """Heater room is SplitMode.OFF in cooling, split room cools normally."""
+        config = ControllerConfig(
+            kp=5.0, ki=0.0, setpoint=24.0, split_deadband=0.5
+        )
+        ctrl = PumpAheadController(
+            config,
+            ["heater_room", "split_room"],
+            room_has_split={"heater_room": True, "split_room": True},
+            room_auxiliary_type={
+                "heater_room": "heater",
+                "split_room": "split",
+            },
+        )
+        # Both rooms are hot (T_room > setpoint) in cooling mode.
+        # Cooling error = T_room - setpoint = 26 - 24 = 2 > 0.5 deadband.
+        meas = {
+            "heater_room": _make_measurements(
+                t_room=26.0, hp_mode=HeatPumpMode.COOLING
+            ),
+            "split_room": _make_measurements(
+                t_room=26.0, hp_mode=HeatPumpMode.COOLING
+            ),
+        }
+        actions = ctrl.step(meas)
+        # Heater room is passive — no split action.
+        assert actions["heater_room"].split_mode == SplitMode.OFF
+        assert actions["heater_room"].split_setpoint == 0.0
+        # Split room activates cooling normally.
+        assert actions["split_room"].split_mode == SplitMode.COOLING
+
+    def test_heater_activates_in_heating_mode(self) -> None:
+        """Heater room activates normally in heating mode (no short-circuit)."""
+        config = ControllerConfig(
+            kp=5.0, ki=0.0, setpoint=24.0, split_deadband=0.5
+        )
+        ctrl = PumpAheadController(
+            config,
+            ["heater_room"],
+            room_has_split={"heater_room": True},
+            room_auxiliary_type={"heater_room": "heater"},
+        )
+        # Heating mode, error = 24 - 22 = 2 > 0.5 deadband => heater activates.
+        meas = {
+            "heater_room": _make_measurements(
+                t_room=22.0, hp_mode=HeatPumpMode.HEATING
+            ),
+        }
+        actions = ctrl.step(meas)
+        assert actions["heater_room"].split_mode == SplitMode.HEATING
+
+    def test_heater_runtime_window_not_contaminated_in_cooling(self) -> None:
+        """Cooling-mode short-circuit does not accumulate split runtime."""
+        config = ControllerConfig(
+            kp=5.0, ki=0.0, setpoint=24.0, split_deadband=0.5
+        )
+        ctrl = PumpAheadController(
+            config,
+            ["heater_room"],
+            room_has_split={"heater_room": True},
+            room_auxiliary_type={"heater_room": "heater"},
+        )
+        for _ in range(30):
+            meas = {
+                "heater_room": _make_measurements(
+                    t_room=26.0, hp_mode=HeatPumpMode.COOLING
+                ),
+            }
+            ctrl.step(meas)
+        diag = ctrl.get_diagnostics()
+        assert diag["heater_room"]["split_runtime_minutes"] == pytest.approx(0.0)
+
+    def test_unknown_room_in_auxiliary_type_raises(self) -> None:
+        """room_auxiliary_type with unknown room name raises ValueError."""
+        config = ControllerConfig(kp=5.0, ki=0.0, setpoint=21.0)
+        with pytest.raises(ValueError, match="unknown room names"):
+            PumpAheadController(
+                config,
+                ["room_a"],
+                room_auxiliary_type={"ghost": "heater"},
+            )
+
+    def test_invalid_auxiliary_type_value_raises(self) -> None:
+        """Unsupported value in room_auxiliary_type raises ValueError."""
+        config = ControllerConfig(kp=5.0, ki=0.0, setpoint=21.0)
+        with pytest.raises(ValueError, match="must be 'split' or 'heater'"):
+            PumpAheadController(
+                config,
+                ["room_a"],
+                room_auxiliary_type={"room_a": "turbo"},
+            )

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -551,9 +551,7 @@ class TestParametricSweeps:
         assert heating.duration_minutes == 2880
         assert "lazienka" in heating.room_overrides
         assert heating.room_overrides["lazienka"].setpoint == 24.0
-        lazienka = next(
-            r for r in heating.building.rooms if r.name == "lazienka"
-        )
+        lazienka = next(r for r in heating.building.rooms if r.name == "lazienka")
         assert lazienka.auxiliary_type == "heater"
         assert lazienka.has_split is True
         assert lazienka.split_power_w == 300.0

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -19,6 +19,8 @@ from pumpahead.config import (
 from pumpahead.scenarios import (
     PARAMETRIC_SWEEPS,
     SCENARIO_LIBRARY,
+    bathroom_heater,
+    bathroom_heater_cooling,
     cold_snap,
     cwu_heavy,
     dew_point_stress,
@@ -46,9 +48,9 @@ class TestScenarioConstruction:
         """SCENARIO_LIBRARY contains at least 8 single scenarios."""
         assert len(SCENARIO_LIBRARY) >= 8
 
-    def test_exactly_15_single_scenarios(self) -> None:
-        """SCENARIO_LIBRARY has exactly 15 entries."""
-        assert len(SCENARIO_LIBRARY) == 15
+    def test_exactly_17_single_scenarios(self) -> None:
+        """SCENARIO_LIBRARY has exactly 17 entries."""
+        assert len(SCENARIO_LIBRARY) == 17
 
     def test_exactly_2_parametric_sweeps(self) -> None:
         """PARAMETRIC_SWEEPS has exactly 2 entries."""
@@ -538,6 +540,28 @@ class TestParametricSweeps:
         for gen in PARAMETRIC_SWEEPS.values():
             total += len(gen())
         assert total >= 10
+
+    def test_bathroom_heater_registered(self) -> None:
+        """bathroom_heater and bathroom_heater_cooling are in the library."""
+        assert "bathroom_heater" in SCENARIO_LIBRARY
+        assert "bathroom_heater_cooling" in SCENARIO_LIBRARY
+        heating = bathroom_heater()
+        assert heating.name == "bathroom_heater"
+        assert heating.mode == "heating"
+        assert heating.duration_minutes == 2880
+        assert "lazienka" in heating.room_overrides
+        assert heating.room_overrides["lazienka"].setpoint == 24.0
+        lazienka = next(
+            r for r in heating.building.rooms if r.name == "lazienka"
+        )
+        assert lazienka.auxiliary_type == "heater"
+        assert lazienka.has_split is True
+        assert lazienka.split_power_w == 300.0
+        assert lazienka.ufh_cooling_max_power_w == 0.0
+
+        cooling = bathroom_heater_cooling()
+        assert cooling.mode == "cooling"
+        assert "lazienka" in cooling.room_overrides
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #130

## Summary
Adds per-room heating-only auxiliary mode so the bathroom can be modelled with a 300 W electric resistive heater that tracks a 24°C override setpoint in heating mode while staying fully passive in cooling mode (Axiom #3 — splits never oppose the HP mode).

## Changes
- `RoomConfig.auxiliary_type: Literal["split","heater"]` with validation
- `SimScenario.room_overrides: dict[str, ControllerConfig]` validated against building rooms
- `PumpAheadController` heater guard short-circuits heater rooms to `SplitMode.OFF` in cooling mode before `SplitCoordinator.decide()`
- New profile `modern_bungalow_with_bathroom_heater` (300 W heater on lazienka)
- New scenarios `bathroom_heater` (heating, T_out=-5°C) + `bathroom_heater_cooling` (hot sinusoid)
- 7 new simulation tests in `TestBathroomHeater` + unit tests for validation and controller guard

## Test plan
- [x] ruff check pumpahead tests — clean
- [x] mypy pumpahead — clean (35 files)
- [x] 374 unit tests pass
- [x] 7 TestBathroomHeater simulation tests pass
- [x] Bathroom reaches 24°C, rest of house at 20°C
- [x] Heater activates in heating, OFF in cooling
- [x] assert_floor_temp_safe / no_opposing_action / no_priority_inversion all pass