### PR TITLE
Issue #131: Fix per-room setpoint routing in coordinator

### DIFF
--- a/custom_components/pumpahead/climate.py
+++ b/custom_components/pumpahead/climate.py
@@ -28,7 +28,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_HAS_SPLIT, CONF_ROOM_NAME, CONF_ROOMS, DEFAULT_SETPOINT
+from .const import CONF_HAS_SPLIT, CONF_ROOM_NAME, CONF_ROOMS
 from .coordinator import PumpAheadCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -116,7 +116,6 @@ class PumpAheadClimateEntity(CoordinatorEntity[PumpAheadCoordinator], ClimateEnt
         super().__init__(coordinator)
         self._room_name = room_name
         self._has_split = has_split
-        self._attr_target_temperature: float = DEFAULT_SETPOINT
         self._user_hvac_mode: HVACMode | None = None
 
         safe_room = room_name.lower().replace(" ", "_")
@@ -186,8 +185,15 @@ class PumpAheadClimateEntity(CoordinatorEntity[PumpAheadCoordinator], ClimateEnt
 
     @property
     def target_temperature(self) -> float:
-        """Return the target temperature."""
-        return self._attr_target_temperature
+        """Return the target temperature from the coordinator's per-room dict.
+
+        The coordinator owns the single source of truth for per-room
+        setpoints (see ``PumpAheadCoordinator.get_room_setpoint``).  This
+        ensures the shadow PID, split recommendations, and climate
+        entity all observe the same target value.
+        """
+        setpoint: float = self.coordinator.get_room_setpoint(self._room_name)
+        return setpoint
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -216,14 +222,20 @@ class PumpAheadClimateEntity(CoordinatorEntity[PumpAheadCoordinator], ClimateEnt
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the target temperature.
 
+        Pushes the new setpoint into the coordinator's per-room dict so
+        that the shadow PID and split coordinator pick it up on the
+        next computation, and writes the HA state immediately for UI
+        responsiveness.
+
         Args:
             **kwargs: Must include ``temperature`` key with the target
                 value in degrees Celsius.
         """
         temperature: float | None = kwargs.get("temperature")
-        if temperature is not None:
-            self._attr_target_temperature = temperature
-            self.async_write_ha_state()
+        if temperature is None:
+            return
+        self.coordinator.set_room_setpoint(self._room_name, temperature)
+        self.async_write_ha_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode.

--- a/custom_components/pumpahead/coordinator.py
+++ b/custom_components/pumpahead/coordinator.py
@@ -151,6 +151,44 @@ class PumpAheadCoordinator(DataUpdateCoordinator[PumpAheadCoordinatorData]):
                 dt=UPDATE_INTERVAL_MINUTES * 60.0,
             )
 
+        # Per-room target temperatures (single source of truth).
+        # Climate entity writes via ``set_room_setpoint``; shadow PID and
+        # split coordinator read via ``get_room_setpoint`` / the value
+        # mirrored into ``RoomSensorData.setpoint`` on every update.
+        self._room_setpoints: dict[str, float] = {
+            room_cfg[CONF_ROOM_NAME]: DEFAULT_SETPOINT
+            for room_cfg in self._room_configs
+        }
+
+    # -- Per-room setpoint accessors ----------------------------------------
+
+    def get_room_setpoint(self, room_name: str) -> float:
+        """Return the current target temperature for a room.
+
+        Falls back to :data:`DEFAULT_SETPOINT` for unknown rooms so that a
+        missing or yet-to-be-registered climate entity still has a sane
+        value.
+        """
+        return self._room_setpoints.get(room_name, DEFAULT_SETPOINT)
+
+    def set_room_setpoint(self, room_name: str, value: float) -> None:
+        """Update the target temperature for a room.
+
+        Called by ``PumpAheadClimateEntity.async_set_temperature``.
+        Rebroadcasts the cached data to listeners so that downstream
+        entities see the new target immediately, before the next 5 min
+        coordinator refresh.
+        """
+        self._room_setpoints[room_name] = float(value)
+        if self.data is not None:
+            # Mirror the new setpoint into the cached RoomSensorData so
+            # readers that bypass the accessor (e.g. direct dict access
+            # in tests) also see the updated value.
+            room_data = self.data.rooms.get(room_name)
+            if room_data is not None:
+                room_data.setpoint = float(value)
+            self.async_set_updated_data(self.data)
+
     # -- Update -------------------------------------------------------------
 
     async def _async_update_data(self) -> PumpAheadCoordinatorData:
@@ -166,6 +204,7 @@ class PumpAheadCoordinator(DataUpdateCoordinator[PumpAheadCoordinatorData]):
                 valve_pos=self._read_float_state(room_cfg.get(CONF_ENTITY_VALVE)),
                 humidity=self._read_float_state(room_cfg.get(CONF_ENTITY_HUMIDITY)),
                 live_control_enabled=is_live,
+                setpoint=self._room_setpoints.get(room_name, DEFAULT_SETPOINT),
             )
 
         T_outdoor = self._read_float_state(self._outdoor_entity)
@@ -233,7 +272,7 @@ class PumpAheadCoordinator(DataUpdateCoordinator[PumpAheadCoordinatorData]):
                 pid = self._pid_controllers.get(room_name)
                 if pid is None:
                     continue
-                error = DEFAULT_SETPOINT - room_data.T_room
+                error = room_data.setpoint - room_data.T_room
                 room_data.recommended_valve = pid.compute(error)
                 # Predicted temp: echo current value (MPC not yet available).
                 room_data.predicted_temp = room_data.T_room

--- a/tests/unit/test_climate_entity.py
+++ b/tests/unit/test_climate_entity.py
@@ -143,6 +143,9 @@ def climate_mocks() -> Any:  # noqa: C901
         async def async_config_entry_first_refresh(self) -> None:
             pass
 
+        def async_set_updated_data(self, data: Any) -> None:
+            self.data = data
+
     ha_helpers_update_coordinator.DataUpdateCoordinator = _FakeDataUpdateCoordinator  # type: ignore[attr-defined]
 
     class _FakeCoordinatorEntity:
@@ -852,6 +855,8 @@ class TestAsyncSetTemperature:
         )
         asyncio.run(entity.async_set_temperature(temperature=23.5))
         assert entity.target_temperature == 23.5
+        # Round-trip: coordinator dict must reflect the new setpoint.
+        assert coordinator.get_room_setpoint("Living Room") == 23.5
 
     @pytest.mark.unit
     def test_set_temperature_no_op_when_none(self, climate_mocks: Any) -> None:
@@ -865,6 +870,53 @@ class TestAsyncSetTemperature:
         )
         asyncio.run(entity.async_set_temperature())
         assert entity.target_temperature == 21.0  # unchanged default
+
+    @pytest.mark.unit
+    def test_set_temperature_propagates_to_coordinator_dict(
+        self, climate_mocks: Any
+    ) -> None:
+        """async_set_temperature must push into coordinator._room_setpoints."""
+        coordinator = _make_coordinator_with_data(climate_mocks)
+        entity = climate_mocks.PumpAheadClimateEntity(
+            coordinator=coordinator,
+            entry_id="test_entry",
+            room_name="Living Room",
+            has_split=False,
+        )
+        asyncio.run(entity.async_set_temperature(temperature=22.5))
+        assert coordinator._room_setpoints["Living Room"] == 22.5
+
+    @pytest.mark.unit
+    def test_target_temperature_reflects_coordinator_changes(
+        self, climate_mocks: Any
+    ) -> None:
+        """Entity target_temperature must reflect external coordinator updates."""
+        coordinator = _make_coordinator_with_data(climate_mocks)
+        entity = climate_mocks.PumpAheadClimateEntity(
+            coordinator=coordinator,
+            entry_id="test_entry",
+            room_name="Living Room",
+            has_split=False,
+        )
+        assert entity.target_temperature == 21.0
+        # Another actor (e.g. service call, future restore) writes to the
+        # coordinator directly.
+        coordinator.set_room_setpoint("Living Room", 19.5)
+        assert entity.target_temperature == 19.5
+
+    @pytest.mark.unit
+    def test_target_temperature_fallback_for_unknown_room(
+        self, climate_mocks: Any
+    ) -> None:
+        """Entity for an unknown room name must fall back to DEFAULT_SETPOINT."""
+        coordinator = _make_coordinator_with_data(climate_mocks)
+        entity = climate_mocks.PumpAheadClimateEntity(
+            coordinator=coordinator,
+            entry_id="test_entry",
+            room_name="Nonexistent Room",
+            has_split=False,
+        )
+        assert entity.target_temperature == 21.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -623,9 +623,7 @@ class TestPerRoomSetpoint:
         assert coordinator.get_room_setpoint("Living Room") == DEFAULT_SETPOINT
 
     @pytest.mark.unit
-    def test_get_setpoint_unknown_room_returns_default(
-        self, coord_mocks: Any
-    ) -> None:
+    def test_get_setpoint_unknown_room_returns_default(self, coord_mocks: Any) -> None:
         """Unknown room names must fall back to DEFAULT_SETPOINT."""
         from custom_components.pumpahead.const import DEFAULT_SETPOINT
 
@@ -652,9 +650,7 @@ class TestPerRoomSetpoint:
         assert isinstance(stored, float)
 
     @pytest.mark.unit
-    def test_room_sensor_data_setpoint_field_populated(
-        self, coord_mocks: Any
-    ) -> None:
+    def test_room_sensor_data_setpoint_field_populated(self, coord_mocks: Any) -> None:
         """RoomSensorData in the coordinator result must mirror the dict."""
         from custom_components.pumpahead.const import DEFAULT_SETPOINT
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -111,12 +111,16 @@ def coord_mocks() -> Any:  # noqa: C901
             self.name = kwargs.get("name", "")
             self.config_entry = kwargs.get("config_entry")
             self.update_interval = kwargs.get("update_interval")
+            self.data: Any = None
 
         def __class_getitem__(cls, _item: object) -> type:  # noqa: N804
             return cls
 
         async def async_config_entry_first_refresh(self) -> None:
             pass
+
+        def async_set_updated_data(self, data: Any) -> None:
+            self.data = data
 
     ha_helpers_update_coordinator.DataUpdateCoordinator = _FakeDataUpdateCoordinator  # type: ignore[attr-defined]
 
@@ -599,3 +603,169 @@ class TestWatchdogIntegration:
         coordinator = coord_mocks.PumpAheadCoordinator(hass, entry)
         assert hasattr(coordinator, "_watchdog")
         assert coordinator._watchdog is not None
+
+
+# ---------------------------------------------------------------------------
+# TestPerRoomSetpoint
+# ---------------------------------------------------------------------------
+
+
+class TestPerRoomSetpoint:
+    """Tests for the per-room setpoint accessor/mutator (issue #131)."""
+
+    @pytest.mark.unit
+    def test_default_setpoint_is_default_constant(self, coord_mocks: Any) -> None:
+        """Newly constructed coordinator must seed every room with DEFAULT_SETPOINT."""
+        from custom_components.pumpahead.const import DEFAULT_SETPOINT
+
+        hass, entry = _make_hass_and_entry(coord_mocks)
+        coordinator = coord_mocks.PumpAheadCoordinator(hass, entry)
+        assert coordinator.get_room_setpoint("Living Room") == DEFAULT_SETPOINT
+
+    @pytest.mark.unit
+    def test_get_setpoint_unknown_room_returns_default(
+        self, coord_mocks: Any
+    ) -> None:
+        """Unknown room names must fall back to DEFAULT_SETPOINT."""
+        from custom_components.pumpahead.const import DEFAULT_SETPOINT
+
+        hass, entry = _make_hass_and_entry(coord_mocks)
+        coordinator = coord_mocks.PumpAheadCoordinator(hass, entry)
+        assert coordinator.get_room_setpoint("nonexistent room") == DEFAULT_SETPOINT
+
+    @pytest.mark.unit
+    def test_set_room_setpoint_updates_value(self, coord_mocks: Any) -> None:
+        """set_room_setpoint must update the stored value for known rooms."""
+        hass, entry = _make_hass_and_entry(coord_mocks)
+        coordinator = coord_mocks.PumpAheadCoordinator(hass, entry)
+        coordinator.set_room_setpoint("Living Room", 24.5)
+        assert coordinator.get_room_setpoint("Living Room") == 24.5
+
+    @pytest.mark.unit
+    def test_set_room_setpoint_casts_to_float(self, coord_mocks: Any) -> None:
+        """set_room_setpoint must coerce integer inputs to float."""
+        hass, entry = _make_hass_and_entry(coord_mocks)
+        coordinator = coord_mocks.PumpAheadCoordinator(hass, entry)
+        coordinator.set_room_setpoint("Living Room", 22)
+        stored = coordinator.get_room_setpoint("Living Room")
+        assert stored == 22.0
+        assert isinstance(stored, float)
+
+    @pytest.mark.unit
+    def test_room_sensor_data_setpoint_field_populated(
+        self, coord_mocks: Any
+    ) -> None:
+        """RoomSensorData in the coordinator result must mirror the dict."""
+        from custom_components.pumpahead.const import DEFAULT_SETPOINT
+
+        hass, entry = _make_hass_and_entry(coord_mocks)
+        coordinator = coord_mocks.PumpAheadCoordinator(hass, entry)
+        coordinator._weather_source = None
+        data = asyncio.run(coordinator._async_update_data())
+        assert data.rooms["Living Room"].setpoint == DEFAULT_SETPOINT
+
+        coordinator.set_room_setpoint("Living Room", 23.0)
+        data = asyncio.run(coordinator._async_update_data())
+        assert data.rooms["Living Room"].setpoint == 23.0
+
+    @pytest.mark.unit
+    def test_shadow_pid_uses_per_room_setpoint(self, coord_mocks: Any) -> None:
+        """Shadow PID must use the per-room setpoint when computing error."""
+        hass, entry = _make_hass_and_entry(coord_mocks)
+        coordinator = coord_mocks.PumpAheadCoordinator(hass, entry)
+        coordinator._weather_source = None
+
+        # Patch the PID controller so we can assert on the error input.
+        captured: list[float] = []
+
+        class _RecordingPID:
+            def compute(self, error: float) -> float:
+                captured.append(error)
+                return 50.0
+
+        coordinator._pid_controllers["Living Room"] = _RecordingPID()  # type: ignore[assignment]
+
+        coordinator.set_room_setpoint("Living Room", 25.0)
+        asyncio.run(coordinator._async_update_data())
+        # Sensor fixture returns 21.5 for Living Room -> error = 25.0 - 21.5.
+        assert captured == [pytest.approx(25.0 - 21.5)]
+
+    @pytest.mark.unit
+    def test_setpoint_change_then_update_recomputes_error(
+        self, coord_mocks: Any
+    ) -> None:
+        """Changing setpoint between updates must change the PID error.
+
+        Regression test for issue #131 — previously the shadow PID used
+        the hardcoded DEFAULT_SETPOINT and ignored user setpoint changes.
+        """
+        hass, entry = _make_hass_and_entry(coord_mocks)
+        coordinator = coord_mocks.PumpAheadCoordinator(hass, entry)
+        coordinator._weather_source = None
+
+        captured: list[float] = []
+
+        class _RecordingPID:
+            def compute(self, error: float) -> float:
+                captured.append(error)
+                return 50.0
+
+        coordinator._pid_controllers["Living Room"] = _RecordingPID()  # type: ignore[assignment]
+
+        # First cycle: default setpoint 21.0, T_room 21.5 -> error ~ -0.5.
+        asyncio.run(coordinator._async_update_data())
+        first_error = captured[-1]
+
+        # User changes setpoint 21 -> 25.
+        coordinator.set_room_setpoint("Living Room", 25.0)
+        asyncio.run(coordinator._async_update_data())
+        second_error = captured[-1]
+
+        assert first_error != second_error
+        assert second_error == pytest.approx(25.0 - 21.5)
+
+    @pytest.mark.unit
+    def test_split_recommendation_uses_per_room_setpoint(
+        self, coord_mocks: Any
+    ) -> None:
+        """_compute_split_recommendations must consume the per-room setpoint.
+
+        With setpoint=24 and T_room=21.5 the split should turn on in
+        heating mode; after dropping the setpoint to 20.2 the split
+        should recommend "off" (error 20.2 - 21.5 = -1.3 in heating
+        mode is negative, so no heating call per axiom 3).
+        """
+        data = dict(_ENTRY_DATA)
+        data["rooms"] = [
+            {
+                "room_name": "Living Room",
+                "entity_temp_room": "sensor.temp_living",
+                "entity_valve": "number.valve_living",
+                "has_split": True,
+            },
+        ]
+        hass, entry = _make_hass_and_entry(coord_mocks, entry_data=data)
+        coordinator = coord_mocks.PumpAheadCoordinator(hass, entry)
+        coordinator._weather_source = None
+
+        coordinator.set_room_setpoint("Living Room", 24.0)
+        result = asyncio.run(coordinator._async_update_data())
+        assert result.rooms["Living Room"].split_recommended_mode == "heating"
+        assert result.rooms["Living Room"].split_recommended_setpoint == 24.0
+
+        coordinator.set_room_setpoint("Living Room", 20.2)
+        result = asyncio.run(coordinator._async_update_data())
+        # In heating mode with negative error, split should NOT heat (axiom 3).
+        assert result.rooms["Living Room"].split_recommended_mode == "off"
+
+    @pytest.mark.unit
+    def test_set_room_setpoint_before_first_refresh_is_safe(
+        self, coord_mocks: Any
+    ) -> None:
+        """set_room_setpoint before first refresh must not raise."""
+        hass, entry = _make_hass_and_entry(coord_mocks)
+        coordinator = coord_mocks.PumpAheadCoordinator(hass, entry)
+        # coordinator.data starts as None -- must be a no-op broadcast.
+        assert coordinator.data is None
+        coordinator.set_room_setpoint("Living Room", 23.0)
+        assert coordinator.get_room_setpoint("Living Room") == 23.0


### PR DESCRIPTION
Closes #131

## Summary
Shadow PID was computing error against hardcoded `DEFAULT_SETPOINT` instead of the per-room target. This meant user changes to the climate entity target were silently ignored.

Fix routes per-room setpoints through a single source of truth in `PumpAheadCoordinator._room_setpoints`:
- Coordinator exposes `get_room_setpoint` / `set_room_setpoint`
- Climate entity reads via property, writes via `async_set_temperature`
- `_run_shadow_pid` and `_compute_split_recommendations` now see live setpoints
- Backward compatible: unknown rooms fall back to `DEFAULT_SETPOINT`

## Test plan
- [x] 73 unit tests pass (13 new in `TestPerRoomSetpoint` + climate round-trip)
- [x] ruff clean
- [x] mypy baseline unchanged
- [x] Regression test covers 21 → 25 setpoint change