### PR TITLE
Issue #142: Add pumpahead/ufh_loop.py with EN 1264 reduced formula

### DIFF
--- a/pumpahead/__init__.py
+++ b/pumpahead/__init__.py
@@ -167,6 +167,11 @@ from pumpahead.split_coordinator import (
     SplitCoordinator,
     SplitDecision,
 )
+from pumpahead.ufh_loop import (
+    LoopGeometry,
+    loop_power,
+    loop_power_with_valve,
+)
 from pumpahead.visualization import (
     generate_plots,
     plot_dashboard,
@@ -254,6 +259,7 @@ __all__ = [
     "InternalGainProfile",
     "IdentificationResult",
     "KalmanEstimator",
+    "LoopGeometry",
     "Measurements",
     "ModeController",
     "MPCAdapter",
@@ -333,6 +339,8 @@ __all__ = [
     "leaky_old_house",
     "load_json",
     "load_pickle",
+    "loop_power",
+    "loop_power_with_valve",
     "generate_safety_yaml",
     "generate_safety_yaml_for_room",
     "generate_plots",

--- a/pumpahead/ufh_loop.py
+++ b/pumpahead/ufh_loop.py
@@ -1,0 +1,323 @@
+"""UFH loop thermal power calculation (EN 1264 reduced formula).
+
+Implements the simplified EN 1264 formula for underfloor heating loop
+thermal power output:
+
+    Q = U x A x DeltaT_log
+
+where *U* is the overall heat transfer coefficient through the PE-X pipe
+wall, *A* is the effective floor area, and *DeltaT_log* is the
+log-mean temperature difference between the supply/return water and the
+slab.
+
+The module enforces Axiom #3 (splits never oppose the mode) at the
+function level: ``loop_power`` returns exactly ``0.0`` when the
+temperature gradient would drive heat in the wrong direction.
+
+Public symbols:
+    ``LoopGeometry``            — frozen dataclass with pipe dimensions.
+    ``loop_power``              — EN 1264 reduced power [W].
+    ``loop_power_with_valve``   — power scaled by valve duty cycle [0, 1].
+
+Units:
+    Temperatures: degC
+    Lengths: m (except pipe dimensions in mm)
+    Power: W
+    Valve position: 0.0 – 1.0 (duty cycle fraction)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from pumpahead.config import RoomConfig
+
+# ---------------------------------------------------------------------------
+# Physical constants
+# ---------------------------------------------------------------------------
+
+K_PEX: float = 0.35
+"""Thermal conductivity of PE-X pipe [W/(m*K)]."""
+
+DEFAULT_DT_HEATING: float = 5.0
+"""Default supply–return temperature drop in heating mode [degC]."""
+
+DEFAULT_DT_COOLING: float = 3.0
+"""Default return–supply temperature rise in cooling mode [degC]."""
+
+_EPSILON: float = 1e-6
+"""Guard threshold for near-equal delta-T values in LMTD calculation."""
+
+
+# ---------------------------------------------------------------------------
+# LoopGeometry — frozen dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LoopGeometry:
+    """Pipe geometry extracted from a ``RoomConfig`` or provided manually.
+
+    All five fields are validated in ``__post_init__``.
+
+    Attributes:
+        effective_pipe_length_m: Total installed pipe length [m] (> 0).
+        pipe_spacing_m: Centre-to-centre pipe spacing [m] (> 0).
+        pipe_diameter_outer_mm: Outer pipe diameter [mm] (> 0).
+        pipe_wall_thickness_mm: Pipe wall thickness [mm]
+            (> 0, < ``pipe_diameter_outer_mm / 2``).
+        area_m2: Effective heated floor area [m^2] (> 0).
+    """
+
+    effective_pipe_length_m: float
+    pipe_spacing_m: float
+    pipe_diameter_outer_mm: float
+    pipe_wall_thickness_mm: float
+    area_m2: float
+
+    def __post_init__(self) -> None:
+        """Validate all geometry fields.
+
+        Raises:
+            ValueError: If any field is out of range.
+        """
+        if self.effective_pipe_length_m <= 0:
+            msg = (
+                f"effective_pipe_length_m must be > 0, "
+                f"got {self.effective_pipe_length_m}"
+            )
+            raise ValueError(msg)
+        if self.pipe_spacing_m <= 0:
+            msg = f"pipe_spacing_m must be > 0, got {self.pipe_spacing_m}"
+            raise ValueError(msg)
+        if self.pipe_diameter_outer_mm <= 0:
+            msg = (
+                f"pipe_diameter_outer_mm must be > 0, got {self.pipe_diameter_outer_mm}"
+            )
+            raise ValueError(msg)
+        if self.pipe_wall_thickness_mm <= 0:
+            msg = (
+                f"pipe_wall_thickness_mm must be > 0, got {self.pipe_wall_thickness_mm}"
+            )
+            raise ValueError(msg)
+        if self.pipe_wall_thickness_mm >= self.pipe_diameter_outer_mm / 2:
+            msg = (
+                f"pipe_wall_thickness_mm ({self.pipe_wall_thickness_mm}) "
+                f"must be < pipe_diameter_outer_mm / 2 "
+                f"({self.pipe_diameter_outer_mm / 2})"
+            )
+            raise ValueError(msg)
+        if self.area_m2 <= 0:
+            msg = f"area_m2 must be > 0, got {self.area_m2}"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_room_config(cls, room: RoomConfig) -> LoopGeometry:
+        """Extract loop geometry from an existing ``RoomConfig``.
+
+        The pipe spacing is either taken directly from
+        ``room.pipe_spacing_m`` or estimated as
+        ``room.area_m2 / room.effective_pipe_length_m``.
+
+        Args:
+            room: Room configuration with pipe geometry fields set.
+
+        Returns:
+            ``LoopGeometry`` instance.
+
+        Raises:
+            ValueError: If the ``RoomConfig`` has no pipe geometry
+                configured (both ``pipe_length_m`` and ``pipe_spacing_m``
+                are ``None``).
+        """
+        length = room.effective_pipe_length_m  # may raise ValueError
+        if room.pipe_spacing_m is not None:
+            spacing = room.pipe_spacing_m
+        else:
+            spacing = room.area_m2 / length
+        return cls(
+            effective_pipe_length_m=length,
+            pipe_spacing_m=spacing,
+            pipe_diameter_outer_mm=room.pipe_diameter_outer_mm,
+            pipe_wall_thickness_mm=room.pipe_wall_thickness_mm,
+            area_m2=room.area_m2,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _delta_t_log(delta_t_in: float, delta_t_out: float) -> float:
+    """Log-mean temperature difference (LMTD).
+
+    When both deltas are positive (or both negative for cooling), the
+    standard LMTD formula applies::
+
+        LMTD = (dT_in - dT_out) / ln(dT_in / dT_out)
+
+    Edge cases:
+    - If either delta is <= 0, return 0.0 (no heat transfer).
+    - If the two deltas are nearly equal, return their arithmetic mean
+      to avoid 0/0.
+
+    Args:
+        delta_t_in: Temperature difference at the inlet side [degC].
+        delta_t_out: Temperature difference at the outlet side [degC].
+
+    Returns:
+        Log-mean temperature difference [degC], always >= 0.
+    """
+    if delta_t_in <= 0.0 or delta_t_out <= 0.0:
+        return 0.0
+
+    if abs(delta_t_in - delta_t_out) < _EPSILON:
+        return (delta_t_in + delta_t_out) / 2.0
+
+    return (delta_t_in - delta_t_out) / math.log(delta_t_in / delta_t_out)
+
+
+def _compute_u_effective(geometry: LoopGeometry) -> float:
+    """Compute the effective overall U-value [W/(m^2*K)].
+
+    The per-metre pipe wall conductance is::
+
+        U_pipe_m = 2 * pi * k_pex / ln(d_outer / d_inner)
+
+    A spacing correction reduces the effective conductance::
+
+        f_spacing = 1 / (1 + spacing / (pi * d_outer))
+
+    The overall area-based coefficient is::
+
+        U = U_pipe_m * f_spacing * pipe_length / area
+
+    Args:
+        geometry: Pipe and floor geometry.
+
+    Returns:
+        Effective U-value [W/(m^2*K)].
+    """
+    d_outer_m = geometry.pipe_diameter_outer_mm / 1000.0
+    d_inner_m = (
+        geometry.pipe_diameter_outer_mm - 2.0 * geometry.pipe_wall_thickness_mm
+    ) / 1000.0
+
+    u_pipe_per_m = (2.0 * math.pi * K_PEX) / math.log(d_outer_m / d_inner_m)
+    f_spacing = 1.0 / (1.0 + geometry.pipe_spacing_m / (math.pi * d_outer_m))
+    return (
+        u_pipe_per_m * f_spacing * geometry.effective_pipe_length_m / geometry.area_m2
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def loop_power(
+    t_supply: float,
+    t_slab: float,
+    geometry: LoopGeometry,
+    mode: Literal["heating", "cooling"],
+    t_return_estimate: float | None = None,
+) -> float:
+    """Compute UFH loop thermal power using the EN 1264 reduced formula.
+
+    ``Q = U * A * DeltaT_log``
+
+    In **heating** mode the function returns Q >= 0; in **cooling** mode
+    it returns Q <= 0 (heat extracted from the slab).  If the supply
+    temperature would drive heat in the wrong direction the function
+    returns exactly ``0.0`` (Axiom #3).
+
+    Args:
+        t_supply: Supply water temperature [degC].
+        t_slab: Slab (screed) temperature [degC].
+        geometry: ``LoopGeometry`` instance with pipe and floor data.
+        mode: Operating mode — ``"heating"`` or ``"cooling"``.
+        t_return_estimate: Estimated return water temperature [degC].
+            When ``None`` the return temperature is estimated from
+            ``t_supply`` using ``DEFAULT_DT_HEATING`` (heating) or
+            ``DEFAULT_DT_COOLING`` (cooling).
+
+    Returns:
+        Thermal power [W].  Positive in heating, negative in cooling.
+
+    Raises:
+        ValueError: If *mode* is not ``"heating"`` or ``"cooling"``.
+    """
+    if mode not in ("heating", "cooling"):
+        msg = f"mode must be 'heating' or 'cooling', got '{mode}'"
+        raise ValueError(msg)
+
+    # --- Axiom #3: never oppose the mode ---
+    if mode == "heating" and t_supply <= t_slab:
+        return 0.0
+    if mode == "cooling" and t_supply >= t_slab:
+        return 0.0
+
+    # --- Estimate return temperature ---
+    if t_return_estimate is None:
+        if mode == "heating":
+            t_return_estimate = t_supply - DEFAULT_DT_HEATING
+        else:
+            t_return_estimate = t_supply + DEFAULT_DT_COOLING
+
+    # --- LMTD calculation ---
+    if mode == "heating":
+        delta_t_in = t_supply - t_slab
+        delta_t_out = t_return_estimate - t_slab
+    else:
+        # Cooling: slab is warmer than supply water
+        delta_t_in = t_slab - t_supply
+        delta_t_out = t_slab - t_return_estimate
+
+    dt_log = _delta_t_log(delta_t_in, delta_t_out)
+    if dt_log == 0.0:
+        return 0.0
+
+    u_eff = _compute_u_effective(geometry)
+    q = u_eff * geometry.area_m2 * dt_log
+
+    # Return negative power in cooling mode
+    if mode == "cooling":
+        return -q
+    return q
+
+
+def loop_power_with_valve(
+    valve: float,
+    t_supply: float,
+    t_slab: float,
+    geometry: LoopGeometry,
+    mode: Literal["heating", "cooling"],
+    t_return_estimate: float | None = None,
+) -> float:
+    """Compute UFH loop thermal power scaled by valve position.
+
+    Equivalent to ``valve * loop_power(...)`` with the valve clamped
+    to [0, 1].
+
+    Args:
+        valve: Valve duty cycle [0, 1].  Values outside this range
+            are clamped defensively.
+        t_supply: Supply water temperature [degC].
+        t_slab: Slab (screed) temperature [degC].
+        geometry: ``LoopGeometry`` instance.
+        mode: Operating mode — ``"heating"`` or ``"cooling"``.
+        t_return_estimate: Optional return water temperature [degC].
+
+    Returns:
+        Thermal power [W] scaled by the valve position.
+    """
+    valve_clamped = max(0.0, min(1.0, valve))
+    if valve_clamped == 0.0:
+        return 0.0
+    return valve_clamped * loop_power(
+        t_supply, t_slab, geometry, mode, t_return_estimate
+    )

--- a/tests/unit/test_ufh_loop.py
+++ b/tests/unit/test_ufh_loop.py
@@ -1,0 +1,480 @@
+"""Unit tests for UFH loop thermal power calculation.
+
+Tests cover:
+- TestLoopGeometryValidation: construction, from_room_config, validation errors
+- TestDeltaTLog: known LMTD, equal deltas, zero/negative deltas
+- TestLoopPowerHeating: monotonicity, hard zeros, positive results, sanity range
+- TestLoopPowerCooling: negative results, hard zeros, default dt
+- TestLoopPowerWithValve: valve=0/1/0.5, clamping
+- TestAxiom3Compliance: sweep t_supply for heating/cooling sign invariants
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from pumpahead.config import RoomConfig
+from pumpahead.model import RCParams
+from pumpahead.ufh_loop import (
+    DEFAULT_DT_COOLING,
+    DEFAULT_DT_HEATING,
+    LoopGeometry,
+    _delta_t_log,
+    loop_power,
+    loop_power_with_valve,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _siso_params() -> RCParams:
+    """Standard 3R3C SISO (UFH-only) parameters."""
+    return RCParams(
+        C_air=60_000,
+        C_slab=3_250_000,
+        C_wall=1_500_000,
+        R_sf=0.01,
+        R_wi=0.02,
+        R_wo=0.03,
+        R_ve=0.03,
+        R_ins=0.01,
+        f_conv=0.6,
+        f_rad=0.4,
+        T_ground=10.0,
+        has_split=False,
+    )
+
+
+def _default_geometry() -> LoopGeometry:
+    """Standard 25 m^2 room with 120 m of 16x2 PE-X at 0.15 m spacing."""
+    return LoopGeometry(
+        effective_pipe_length_m=120.0,
+        pipe_spacing_m=0.15,
+        pipe_diameter_outer_mm=16.0,
+        pipe_wall_thickness_mm=2.0,
+        area_m2=25.0,
+    )
+
+
+# ===========================================================================
+# TestLoopGeometryValidation
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestLoopGeometryValidation:
+    """Tests for LoopGeometry construction and validation."""
+
+    def test_valid_construction(self) -> None:
+        """All fields positive and consistent -> no error."""
+        geo = _default_geometry()
+        assert geo.effective_pipe_length_m == 120.0
+        assert geo.pipe_spacing_m == 0.15
+        assert geo.pipe_diameter_outer_mm == 16.0
+        assert geo.pipe_wall_thickness_mm == 2.0
+        assert geo.area_m2 == 25.0
+
+    def test_frozen(self) -> None:
+        """LoopGeometry is immutable."""
+        geo = _default_geometry()
+        with pytest.raises(AttributeError):
+            geo.area_m2 = 30.0  # type: ignore[misc]
+
+    def test_negative_pipe_length_raises(self) -> None:
+        with pytest.raises(ValueError, match="effective_pipe_length_m must be > 0"):
+            LoopGeometry(
+                effective_pipe_length_m=-1.0,
+                pipe_spacing_m=0.15,
+                pipe_diameter_outer_mm=16.0,
+                pipe_wall_thickness_mm=2.0,
+                area_m2=25.0,
+            )
+
+    def test_zero_pipe_length_raises(self) -> None:
+        with pytest.raises(ValueError, match="effective_pipe_length_m must be > 0"):
+            LoopGeometry(
+                effective_pipe_length_m=0.0,
+                pipe_spacing_m=0.15,
+                pipe_diameter_outer_mm=16.0,
+                pipe_wall_thickness_mm=2.0,
+                area_m2=25.0,
+            )
+
+    def test_negative_spacing_raises(self) -> None:
+        with pytest.raises(ValueError, match="pipe_spacing_m must be > 0"):
+            LoopGeometry(
+                effective_pipe_length_m=120.0,
+                pipe_spacing_m=-0.1,
+                pipe_diameter_outer_mm=16.0,
+                pipe_wall_thickness_mm=2.0,
+                area_m2=25.0,
+            )
+
+    def test_negative_diameter_raises(self) -> None:
+        with pytest.raises(ValueError, match="pipe_diameter_outer_mm must be > 0"):
+            LoopGeometry(
+                effective_pipe_length_m=120.0,
+                pipe_spacing_m=0.15,
+                pipe_diameter_outer_mm=-16.0,
+                pipe_wall_thickness_mm=2.0,
+                area_m2=25.0,
+            )
+
+    def test_wall_too_thick_raises(self) -> None:
+        """Wall thickness >= diameter/2 is physically impossible."""
+        with pytest.raises(ValueError, match="pipe_wall_thickness_mm.*must be <"):
+            LoopGeometry(
+                effective_pipe_length_m=120.0,
+                pipe_spacing_m=0.15,
+                pipe_diameter_outer_mm=16.0,
+                pipe_wall_thickness_mm=8.0,  # == d/2
+                area_m2=25.0,
+            )
+
+    def test_negative_area_raises(self) -> None:
+        with pytest.raises(ValueError, match="area_m2 must be > 0"):
+            LoopGeometry(
+                effective_pipe_length_m=120.0,
+                pipe_spacing_m=0.15,
+                pipe_diameter_outer_mm=16.0,
+                pipe_wall_thickness_mm=2.0,
+                area_m2=-5.0,
+            )
+
+    def test_from_room_config_with_pipe_length(self) -> None:
+        """from_room_config extracts geometry from RoomConfig with pipe_length_m."""
+        room = RoomConfig(
+            name="test_room",
+            area_m2=25.0,
+            params=_siso_params(),
+            pipe_length_m=120.0,
+            pipe_diameter_outer_mm=16.0,
+            pipe_wall_thickness_mm=2.0,
+        )
+        geo = LoopGeometry.from_room_config(room)
+        assert geo.effective_pipe_length_m == 120.0
+        # Spacing estimated as area / length
+        assert geo.pipe_spacing_m == pytest.approx(25.0 / 120.0)
+        assert geo.area_m2 == 25.0
+
+    def test_from_room_config_with_pipe_spacing(self) -> None:
+        """from_room_config extracts geometry from RoomConfig with pipe_spacing_m."""
+        room = RoomConfig(
+            name="test_room",
+            area_m2=25.0,
+            params=_siso_params(),
+            pipe_spacing_m=0.15,
+            pipe_diameter_outer_mm=16.0,
+            pipe_wall_thickness_mm=2.0,
+        )
+        geo = LoopGeometry.from_room_config(room)
+        assert geo.pipe_spacing_m == 0.15
+        # Length estimated from area / spacing * safety factor
+        assert geo.effective_pipe_length_m == pytest.approx(25.0 / 0.15 * 1.1, rel=1e-6)
+        assert geo.area_m2 == 25.0
+
+    def test_from_room_config_no_geometry_raises(self) -> None:
+        """from_room_config raises ValueError when no geometry is configured."""
+        room = RoomConfig(
+            name="test_room",
+            area_m2=25.0,
+            params=_siso_params(),
+        )
+        with pytest.raises(ValueError, match="pipe geometry not configured"):
+            LoopGeometry.from_room_config(room)
+
+
+# ===========================================================================
+# TestDeltaTLog
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestDeltaTLog:
+    """Tests for the private _delta_t_log helper."""
+
+    def test_known_lmtd(self) -> None:
+        """Known LMTD: dT_in=10, dT_out=5 -> (10-5)/ln(10/5) = 7.213."""
+        result = _delta_t_log(10.0, 5.0)
+        expected = (10.0 - 5.0) / math.log(10.0 / 5.0)
+        assert result == pytest.approx(expected, rel=1e-9)
+
+    def test_equal_deltas(self) -> None:
+        """When dT_in == dT_out, result is the arithmetic mean."""
+        result = _delta_t_log(8.0, 8.0)
+        assert result == pytest.approx(8.0, rel=1e-9)
+
+    def test_nearly_equal_deltas(self) -> None:
+        """When dT_in ~= dT_out within epsilon, use arithmetic mean."""
+        result = _delta_t_log(8.0, 8.0 + 1e-12)
+        assert result == pytest.approx(8.0, rel=1e-6)
+
+    def test_zero_delta_in(self) -> None:
+        """dT_in == 0 -> 0.0 (no heat transfer)."""
+        assert _delta_t_log(0.0, 5.0) == 0.0
+
+    def test_zero_delta_out(self) -> None:
+        """dT_out == 0 -> 0.0 (no heat transfer)."""
+        assert _delta_t_log(5.0, 0.0) == 0.0
+
+    def test_negative_delta_in(self) -> None:
+        """Negative dT_in -> 0.0."""
+        assert _delta_t_log(-1.0, 5.0) == 0.0
+
+    def test_negative_delta_out(self) -> None:
+        """Negative dT_out -> 0.0."""
+        assert _delta_t_log(5.0, -2.0) == 0.0
+
+    def test_both_negative(self) -> None:
+        """Both negative -> 0.0."""
+        assert _delta_t_log(-3.0, -5.0) == 0.0
+
+    def test_symmetric_inputs(self) -> None:
+        """LMTD(a, b) == LMTD(b, a) for positive a, b."""
+        assert _delta_t_log(10.0, 5.0) == pytest.approx(
+            _delta_t_log(5.0, 10.0), rel=1e-9
+        )
+
+    def test_result_always_non_negative(self) -> None:
+        """Result is >= 0 for all combinations of positive inputs."""
+        for dt_in in [0.5, 1.0, 5.0, 10.0, 20.0]:
+            for dt_out in [0.5, 1.0, 5.0, 10.0, 20.0]:
+                assert _delta_t_log(dt_in, dt_out) >= 0.0
+
+
+# ===========================================================================
+# TestLoopPowerHeating
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestLoopPowerHeating:
+    """Tests for loop_power in heating mode."""
+
+    def test_positive_result(self) -> None:
+        """Heating with t_supply > t_slab returns Q > 0."""
+        geo = _default_geometry()
+        q = loop_power(35.0, 22.0, geo, "heating")
+        assert q > 0.0
+
+    def test_zero_when_supply_equals_slab(self) -> None:
+        """t_supply == t_slab returns exactly 0.0."""
+        geo = _default_geometry()
+        q = loop_power(22.0, 22.0, geo, "heating")
+        assert q == 0.0
+
+    def test_zero_when_supply_below_slab(self) -> None:
+        """t_supply < t_slab returns 0.0 in heating (Axiom #3)."""
+        geo = _default_geometry()
+        q = loop_power(20.0, 25.0, geo, "heating")
+        assert q == 0.0
+
+    def test_monotonic_with_t_supply(self) -> None:
+        """Higher t_supply -> higher power (monotonically increasing).
+
+        Start from t_slab + DEFAULT_DT_HEATING + 1 to ensure the return
+        temperature is above the slab, keeping both LMTD deltas positive.
+        """
+        geo = _default_geometry()
+        t_slab = 22.0
+        # Return temp = t_supply - 5; both deltas positive when t_supply > 27
+        start = int(t_slab + DEFAULT_DT_HEATING) + 1  # 28
+        supplies = list(range(start, 50))
+        powers = [loop_power(float(t), t_slab, geo, "heating") for t in supplies]
+        for i in range(1, len(powers)):
+            assert powers[i] > powers[i - 1], (
+                f"Power at t_supply={supplies[i]} ({powers[i]:.1f}) "
+                f"<= power at t_supply={supplies[i - 1]} ({powers[i - 1]:.1f})"
+            )
+
+    def test_monotonic_with_pipe_length(self) -> None:
+        """Longer pipe -> more power (same area, spacing, etc.)."""
+        t_supply, t_slab = 35.0, 22.0
+        lengths = [60.0, 80.0, 100.0, 120.0, 150.0]
+        powers = []
+        for length in lengths:
+            geo = LoopGeometry(
+                effective_pipe_length_m=length,
+                pipe_spacing_m=0.15,
+                pipe_diameter_outer_mm=16.0,
+                pipe_wall_thickness_mm=2.0,
+                area_m2=25.0,
+            )
+            powers.append(loop_power(t_supply, t_slab, geo, "heating"))
+        for i in range(1, len(powers)):
+            assert powers[i] > powers[i - 1]
+
+    def test_explicit_return_temp(self) -> None:
+        """Providing t_return_estimate changes the result vs default."""
+        geo = _default_geometry()
+        q_default = loop_power(35.0, 22.0, geo, "heating")
+        q_explicit = loop_power(35.0, 22.0, geo, "heating", t_return_estimate=32.0)
+        # With higher return temp (32 vs 35-5=30), LMTD is larger
+        assert q_explicit > q_default
+
+    def test_sanity_range_watts(self) -> None:
+        """Typical room: Q should be in a plausible range (100-5000 W)."""
+        geo = _default_geometry()
+        q = loop_power(35.0, 22.0, geo, "heating")
+        assert 100.0 < q < 5000.0
+
+    def test_invalid_mode_raises(self) -> None:
+        """Invalid mode string raises ValueError."""
+        geo = _default_geometry()
+        with pytest.raises(ValueError, match="mode must be"):
+            loop_power(35.0, 22.0, geo, "auto")  # type: ignore[arg-type]
+
+
+# ===========================================================================
+# TestLoopPowerCooling
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestLoopPowerCooling:
+    """Tests for loop_power in cooling mode."""
+
+    def test_negative_result(self) -> None:
+        """Cooling with t_supply < t_slab returns Q < 0."""
+        geo = _default_geometry()
+        q = loop_power(16.0, 24.0, geo, "cooling")
+        assert q < 0.0
+
+    def test_zero_when_supply_equals_slab(self) -> None:
+        """t_supply == t_slab returns exactly 0.0."""
+        geo = _default_geometry()
+        q = loop_power(24.0, 24.0, geo, "cooling")
+        assert q == 0.0
+
+    def test_zero_when_supply_above_slab(self) -> None:
+        """t_supply > t_slab returns 0.0 in cooling (Axiom #3)."""
+        geo = _default_geometry()
+        q = loop_power(28.0, 24.0, geo, "cooling")
+        assert q == 0.0
+
+    def test_default_dt_cooling(self) -> None:
+        """Default return temp uses DEFAULT_DT_COOLING offset."""
+        geo = _default_geometry()
+        t_supply = 16.0
+        t_slab = 24.0
+        q_default = loop_power(t_supply, t_slab, geo, "cooling")
+        q_explicit = loop_power(
+            t_supply,
+            t_slab,
+            geo,
+            "cooling",
+            t_return_estimate=t_supply + DEFAULT_DT_COOLING,
+        )
+        assert q_default == pytest.approx(q_explicit, rel=1e-9)
+
+    def test_more_negative_with_lower_supply(self) -> None:
+        """Lower t_supply extracts more heat (more negative Q)."""
+        geo = _default_geometry()
+        t_slab = 24.0
+        q_16 = loop_power(16.0, t_slab, geo, "cooling")
+        q_12 = loop_power(12.0, t_slab, geo, "cooling")
+        assert q_12 < q_16 < 0.0
+
+
+# ===========================================================================
+# TestLoopPowerWithValve
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestLoopPowerWithValve:
+    """Tests for loop_power_with_valve."""
+
+    def test_valve_zero_returns_zero(self) -> None:
+        """valve=0 always returns 0.0."""
+        geo = _default_geometry()
+        assert loop_power_with_valve(0.0, 35.0, 22.0, geo, "heating") == 0.0
+
+    def test_valve_one_equals_full_power(self) -> None:
+        """valve=1 returns full loop_power value."""
+        geo = _default_geometry()
+        q_full = loop_power(35.0, 22.0, geo, "heating")
+        q_valve = loop_power_with_valve(1.0, 35.0, 22.0, geo, "heating")
+        assert q_valve == pytest.approx(q_full, rel=1e-9)
+
+    def test_valve_half(self) -> None:
+        """valve=0.5 returns half of full power."""
+        geo = _default_geometry()
+        q_full = loop_power(35.0, 22.0, geo, "heating")
+        q_half = loop_power_with_valve(0.5, 35.0, 22.0, geo, "heating")
+        assert q_half == pytest.approx(q_full * 0.5, rel=1e-9)
+
+    def test_valve_clamped_above_one(self) -> None:
+        """valve > 1.0 is clamped to 1.0."""
+        geo = _default_geometry()
+        q_full = loop_power(35.0, 22.0, geo, "heating")
+        q_over = loop_power_with_valve(1.5, 35.0, 22.0, geo, "heating")
+        assert q_over == pytest.approx(q_full, rel=1e-9)
+
+    def test_valve_clamped_below_zero(self) -> None:
+        """valve < 0.0 is clamped to 0.0."""
+        geo = _default_geometry()
+        assert loop_power_with_valve(-0.5, 35.0, 22.0, geo, "heating") == 0.0
+
+    def test_valve_with_cooling(self) -> None:
+        """valve scaling works in cooling mode."""
+        geo = _default_geometry()
+        q_full = loop_power(16.0, 24.0, geo, "cooling")
+        q_valve = loop_power_with_valve(0.7, 16.0, 24.0, geo, "cooling")
+        assert q_valve == pytest.approx(q_full * 0.7, rel=1e-9)
+
+
+# ===========================================================================
+# TestAxiom3Compliance
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestAxiom3Compliance:
+    """Axiom #3: loop_power never opposes the mode."""
+
+    def test_heating_never_negative(self) -> None:
+        """Sweep t_supply: heating mode never produces negative power."""
+        geo = _default_geometry()
+        t_slab = 22.0
+        for t_supply_int in range(-10, 60):
+            t_supply = float(t_supply_int)
+            q = loop_power(t_supply, t_slab, geo, "heating")
+            assert q >= 0.0, (
+                f"Heating produced Q={q:.1f} W at t_supply={t_supply}, t_slab={t_slab}"
+            )
+
+    def test_cooling_never_positive(self) -> None:
+        """Sweep t_supply: cooling mode never produces positive power."""
+        geo = _default_geometry()
+        t_slab = 24.0
+        for t_supply_int in range(-10, 60):
+            t_supply = float(t_supply_int)
+            q = loop_power(t_supply, t_slab, geo, "cooling")
+            assert q <= 0.0, (
+                f"Cooling produced Q={q:.1f} W at t_supply={t_supply}, t_slab={t_slab}"
+            )
+
+    def test_heating_with_valve_never_negative(self) -> None:
+        """Valve-scaled heating is also never negative."""
+        geo = _default_geometry()
+        t_slab = 22.0
+        for valve in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            for t_supply_int in range(10, 50):
+                t_supply = float(t_supply_int)
+                q = loop_power_with_valve(valve, t_supply, t_slab, geo, "heating")
+                assert q >= 0.0
+
+    def test_cooling_with_valve_never_positive(self) -> None:
+        """Valve-scaled cooling is also never positive."""
+        geo = _default_geometry()
+        t_slab = 24.0
+        for valve in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            for t_supply_int in range(5, 40):
+                t_supply = float(t_supply_int)
+                q = loop_power_with_valve(valve, t_supply, t_slab, geo, "cooling")
+                assert q <= 0.0


### PR DESCRIPTION
## Summary
- New `pumpahead/ufh_loop.py` module implementing the EN 1264 reduced formula for UFH loop thermal power calculation: `Q = U × A × ΔT_log`
- `LoopGeometry` frozen dataclass with `__post_init__` validation and `from_room_config()` classmethod
- `loop_power()` and `loop_power_with_valve()` with full Axiom #3 enforcement (never oppose mode)
- 44 unit tests across 6 test classes covering monotonicity, sign invariants, edge cases, and valve scaling

## Test plan
- [x] 44/44 unit tests pass (`pytest tests/unit/test_ufh_loop.py`)
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy --strict pumpahead/ufh_loop.py` passes
- [x] Zero `homeassistant` imports in `pumpahead/ufh_loop.py`

Closes #142