### PR TITLE
Issue #143: Rewrite BuildingSimulator._distribute_hp_power to use ufh_loop.loop_power

### DIFF
--- a/pumpahead/ab_testing.py
+++ b/pumpahead/ab_testing.py
@@ -71,6 +71,7 @@ from pumpahead.simulator import (
     Measurements,
     SplitMode,
 )
+from pumpahead.ufh_loop import LoopGeometry
 from pumpahead.weather import WeatherPoint
 
 # ---------------------------------------------------------------------------
@@ -583,12 +584,18 @@ class ABTestRunner:
         rooms: list[SimulatedRoom] = []
         for room_cfg in scenario.building.rooms:
             model = RCModel(room_cfg.params, ModelOrder.THREE, dt=scenario.dt_seconds)
+            try:
+                geometry = LoopGeometry.from_room_config(room_cfg)
+            except ValueError:
+                # Room has no pipe geometry — fall back to legacy shim.
+                geometry = None
             sim_room = SimulatedRoom(
                 room_cfg.name,
                 model,
                 ufh_max_power_w=room_cfg.ufh_max_power_w,
                 split_power_w=room_cfg.split_power_w,
                 q_int_w=room_cfg.q_int_w,
+                loop_geometry=geometry,
             )
             rooms.append(sim_room)
 
@@ -605,6 +612,8 @@ class ABTestRunner:
             hp_max_power_w=scenario.building.hp_max_power_w,
             cwu_schedule=list(scenario.cwu_schedule),
             sensor_noise=noise,
+            weather_comp=scenario.weather_comp,
+            cooling_comp=scenario.cooling_comp,
         )
 
     def _run_single(

--- a/pumpahead/simulated_room.py
+++ b/pumpahead/simulated_room.py
@@ -21,6 +21,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from pumpahead.model import RCModel
+from pumpahead.ufh_loop import LoopGeometry
 from pumpahead.weather import WeatherPoint
 
 
@@ -48,6 +49,7 @@ class SimulatedRoom:
         ufh_cooling_max_power_w: float = 0.0,
         split_power_w: float = 0.0,
         q_int_w: float = 0.0,
+        loop_geometry: LoopGeometry | None = None,
     ) -> None:
         """Initialize the simulated room.
 
@@ -60,6 +62,13 @@ class SimulatedRoom:
                 floor heat transfer.  Zero if no floor cooling.
             split_power_w: Maximum split/AC power [W].  Zero if no split.
             q_int_w: Constant internal heat gains [W] (occupancy, appliances).
+            loop_geometry: Optional ``LoopGeometry`` describing the UFH
+                loop's pipe and floor area.  When provided, the
+                ``BuildingSimulator`` uses the physical EN 1264 model
+                (``pumpahead.ufh_loop.loop_power``) to compute per-room
+                floor power.  When ``None`` (default), the legacy
+                ``valve * ufh_max_power_w`` shim is used — this shim
+                will be removed by issue #144.
         """
         self._name = name
         self._model = model
@@ -67,6 +76,7 @@ class SimulatedRoom:
         self._ufh_cooling_max_power_w = ufh_cooling_max_power_w
         self._split_power_w = split_power_w
         self._q_int_w = q_int_w
+        self._loop_geometry = loop_geometry
 
         # Thermal state: all nodes at 20 degC
         self._x: NDArray[np.float64] = model.reset()
@@ -116,6 +126,11 @@ class SimulatedRoom:
     def ufh_cooling_max_power_w(self) -> float:
         """Return the maximum UFH cooling power at 100 % valve [W]."""
         return self._ufh_cooling_max_power_w
+
+    @property
+    def loop_geometry(self) -> LoopGeometry | None:
+        """Return the UFH loop geometry, or ``None`` if not configured."""
+        return self._loop_geometry
 
     # -- State manipulation --------------------------------------------------
 

--- a/pumpahead/simulator.py
+++ b/pumpahead/simulator.py
@@ -25,11 +25,14 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, replace
 from enum import Enum
+from typing import Literal
 
 from pumpahead.config import CWUCycle
 from pumpahead.sensor_noise import SensorNoise
 from pumpahead.simulated_room import SimulatedRoom
+from pumpahead.ufh_loop import loop_power
 from pumpahead.weather import WeatherSource
+from pumpahead.weather_comp import CoolingCompCurve, WeatherCompCurve
 
 # ---------------------------------------------------------------------------
 # Enumerations
@@ -50,6 +53,20 @@ class SplitMode(Enum):
     OFF = "off"
     HEATING = "heating"
     COOLING = "cooling"
+
+
+# ---------------------------------------------------------------------------
+# Fallback supply temperatures — used only when no weather-compensation
+# curve is supplied.  The chosen values sit inside the default clamp range
+# of ``WeatherCompCurve`` (>=20 C) and ``CoolingCompCurve`` (>=7 C) so
+# they stay representative of a real HP operating point.
+# ---------------------------------------------------------------------------
+
+_FALLBACK_T_SUPPLY_HEATING_C: float = 35.0
+"""Fallback supply temperature used when no WeatherCompCurve is provided."""
+
+_FALLBACK_T_SUPPLY_COOLING_C: float = 18.0
+"""Fallback supply temperature used when no CoolingCompCurve is provided."""
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +160,9 @@ class BuildingSimulator:
         hp_max_power_w: float | None = None,
         cwu_schedule: list[CWUCycle] | None = None,
         sensor_noise: SensorNoise | None = None,
+        *,
+        weather_comp: WeatherCompCurve | None = None,
+        cooling_comp: CoolingCompCurve | None = None,
     ) -> None:
         """Initialize the simulator.
 
@@ -158,6 +178,15 @@ class BuildingSimulator:
             sensor_noise: Optional sensor noise source.  When provided,
                 Gaussian noise is added to T_room and T_slab in returned
                 ``Measurements``.  Does not affect physical state.
+            weather_comp: Optional heating weather-compensation curve.
+                When provided, ``T_supply`` used by the physical UFH
+                model is derived from ``weather_comp.t_supply(T_out)``
+                during heating steps.  ``None`` (default) falls back to
+                ``_FALLBACK_T_SUPPLY_HEATING_C``.
+            cooling_comp: Optional cooling weather-compensation curve.
+                Used only when ``hp_mode == HeatPumpMode.COOLING``.
+                ``None`` (default) falls back to
+                ``_FALLBACK_T_SUPPLY_COOLING_C``.
 
         Raises:
             ValueError: If the room list is empty or contains duplicate
@@ -183,8 +212,14 @@ class BuildingSimulator:
         )
         self._cwu_schedule: list[CWUCycle] = cwu_schedule or []
         self._sensor_noise = sensor_noise
+        self._weather_comp = weather_comp
+        self._cooling_comp = cooling_comp
         self._time_minutes: int = 0
         self._dt_minutes: int = 1
+
+        # Diagnostics populated by ``_distribute_hp_power``.
+        self._last_t_supply_c: float | None = None
+        self._last_q_floor_w: dict[str, float] = {}
 
     # -- Properties ----------------------------------------------------------
 
@@ -212,6 +247,32 @@ class BuildingSimulator:
     def is_cwu_active(self) -> bool:
         """Return whether a CWU cycle is active at the current time."""
         return self._check_cwu_active()
+
+    @property
+    def last_step_info(self) -> dict[str, object]:
+        """Return diagnostics from the most recent ``_distribute_hp_power`` call.
+
+        The returned dictionary contains three keys:
+
+        * ``t_supply_c`` — supply temperature [degC] used in the last
+          distribution step, or ``None`` before any step and when the
+          heat pump was in ``HeatPumpMode.OFF``.
+        * ``q_floor_w`` — per-room allocated floor power [W].  Positive
+          in heating, negative in cooling.  Empty dictionary before any
+          distribution has been performed.
+        * ``hp_mode`` — the current :class:`HeatPumpMode`.
+
+        The ``q_floor_w`` dictionary is a defensive copy — mutating it
+        does not affect subsequent diagnostics.
+
+        Returns:
+            Dictionary with diagnostic state from the last step.
+        """
+        return {
+            "t_supply_c": self._last_t_supply_c,
+            "q_floor_w": dict(self._last_q_floor_w),
+            "hp_mode": self._hp_mode,
+        }
 
     def set_hp_mode(self, mode: HeatPumpMode) -> None:
         """Update the heat pump operating mode.
@@ -456,49 +517,113 @@ class BuildingSimulator:
 
     # -- Private helpers -----------------------------------------------------
 
+    def _compute_t_supply(self, t_out: float) -> float:
+        """Compute supply temperature for the current HP mode.
+
+        Uses the weather-compensation curve when available, otherwise
+        falls back to the module-level constant for the current mode.
+
+        Args:
+            t_out: Current outdoor temperature [degC].
+
+        Returns:
+            Supply temperature [degC].  Returns ``0.0`` when the HP is
+            OFF — callers should not use the value in that case.
+        """
+        if self._hp_mode == HeatPumpMode.HEATING:
+            if self._weather_comp is not None:
+                return self._weather_comp.t_supply(t_out)
+            return _FALLBACK_T_SUPPLY_HEATING_C
+        if self._hp_mode == HeatPumpMode.COOLING:
+            if self._cooling_comp is not None:
+                return self._cooling_comp.t_supply(t_out)
+            return _FALLBACK_T_SUPPLY_COOLING_C
+        # HP OFF — callers short-circuit and should not use this value.
+        return 0.0
+
     def _distribute_hp_power(
         self,
         actions: dict[str, Actions],
     ) -> dict[str, float]:
         """Compute per-room floor power respecting HP capacity.
 
-        In HEATING mode:
-        1. For each room compute demand = (valve / 100) * ufh_max_power_w.
-        2. If total demand <= hp_max_power_w, each room gets its full demand.
-        3. Otherwise, scale down proportionally.
+        Algorithm:
 
-        In COOLING mode:
-        1. For each room compute demand = (valve / 100) * ufh_cooling_max_power_w.
-        2. Scale proportionally if total demand exceeds HP capacity.
-        3. Return negative values (cold water in the slab).
+        1. When the HP is OFF, every room receives zero floor power and
+           diagnostics are reset.
+        2. Otherwise, the supply temperature ``T_supply`` is derived
+           once (per call) from the appropriate weather-compensation
+           curve — ``WeatherCompCurve`` in heating or
+           ``CoolingCompCurve`` in cooling — falling back to
+           ``_FALLBACK_T_SUPPLY_HEATING_C`` / ``_FALLBACK_T_SUPPLY_COOLING_C``
+           when no curve is configured.
+        3. For each room:
+
+           * If the room has a ``loop_geometry`` the *physical* UFH
+             model is used: ``Q_max = loop_power(T_supply, T_slab,
+             geometry, mode)`` — this already carries the mode-correct
+             sign (positive in heating, negative in cooling) and
+             returns ``0.0`` when the gradient is wrong (Axiom #3).
+           * Otherwise a backward-compat shim is applied:
+             ``Q_max = ufh_max_power_w`` in heating or
+             ``-ufh_cooling_max_power_w`` in cooling.  Issue #144
+             removes the shim once every building profile has pipe
+             geometry.
+
+           Per-room demand is ``valve_fraction * Q_max``.
+        4. The absolute total demand is compared against
+           ``hp_max_power_w``.  When the HP cannot cover it all, every
+           room's allocation is scaled uniformly by ``hp_max_power_w /
+           total_abs`` — signs (heating vs cooling) are preserved.
+        5. Diagnostics are stored in ``self._last_t_supply_c`` and
+           ``self._last_q_floor_w`` so :attr:`last_step_info` exposes
+           them for inspection.
 
         Returns:
             Dictionary of allocated floor power [W] keyed by room name.
-            Positive in heating mode, negative in cooling mode.
+            Positive in heating mode, negative in cooling mode, zero
+            when the HP is OFF or the valve is closed.
         """
-        is_cooling = self._hp_mode == HeatPumpMode.COOLING
+        # HP OFF — short-circuit before computing T_supply.
+        if self._hp_mode == HeatPumpMode.OFF:
+            result = {r.name: 0.0 for r in self._rooms}
+            self._last_t_supply_c = None
+            self._last_q_floor_w = dict(result)
+            return result
 
+        t_out = self._weather.get(float(self._time_minutes)).T_out
+        t_supply = self._compute_t_supply(t_out)
+        self._last_t_supply_c = t_supply
+
+        mode_str: Literal["heating", "cooling"] = (
+            "cooling" if self._hp_mode == HeatPumpMode.COOLING else "heating"
+        )
+
+        # Per-room demand (signed: positive heating, negative cooling).
         demands: dict[str, float] = {}
         for r in self._rooms:
-            valve = actions[r.name].valve_position
-            # Use the clamped value that apply_actions would compute
-            clamped = max(0.0, min(100.0, valve))
-            if is_cooling:
-                demands[r.name] = clamped / 100.0 * r.ufh_cooling_max_power_w
+            valve_frac = max(0.0, min(100.0, actions[r.name].valve_position)) / 100.0
+            geometry = r.loop_geometry
+            if geometry is not None:
+                q_max = loop_power(t_supply, r.T_slab, geometry, mode_str)
+            elif mode_str == "heating":
+                q_max = r.ufh_max_power_w
             else:
-                demands[r.name] = clamped / 100.0 * r.ufh_max_power_w
+                # Cooling shim: ``ufh_cooling_max_power_w`` is stored as
+                # a non-negative value — negate it to match the signed
+                # convention used by ``loop_power`` in cooling.
+                q_max = -r.ufh_cooling_max_power_w
+            demands[r.name] = valve_frac * q_max
 
-        total_demand = sum(demands.values())
+        total_abs = sum(abs(d) for d in demands.values())
 
-        if total_demand == 0.0:
+        if total_abs == 0.0:
             result = {name: 0.0 for name in demands}
-        elif total_demand <= self._hp_max_power_w:
-            result = demands
+        elif total_abs <= self._hp_max_power_w:
+            result = dict(demands)
         else:
-            scale = self._hp_max_power_w / total_demand
+            scale = self._hp_max_power_w / total_abs
             result = {name: d * scale for name, d in demands.items()}
 
-        # In cooling mode, power is negative (cold water)
-        if is_cooling:
-            return {name: -d for name, d in result.items()}
+        self._last_q_floor_w = dict(result)
         return result

--- a/tests/simulation/conftest.py
+++ b/tests/simulation/conftest.py
@@ -20,6 +20,7 @@ from pumpahead.simulator import (
     BuildingSimulator,
     HeatPumpMode,
 )
+from pumpahead.ufh_loop import LoopGeometry
 
 # ---------------------------------------------------------------------------
 # Existing fixtures (kept unchanged)
@@ -80,6 +81,11 @@ def _build_simulator(scenario: SimScenario) -> BuildingSimulator:
     rooms: list[SimulatedRoom] = []
     for room_cfg in scenario.building.rooms:
         model = RCModel(room_cfg.params, ModelOrder.THREE, dt=scenario.dt_seconds)
+        try:
+            geometry = LoopGeometry.from_room_config(room_cfg)
+        except ValueError:
+            # Room has no pipe geometry — fall back to legacy shim.
+            geometry = None
         sim_room = SimulatedRoom(
             room_cfg.name,
             model,
@@ -87,6 +93,7 @@ def _build_simulator(scenario: SimScenario) -> BuildingSimulator:
             ufh_cooling_max_power_w=room_cfg.ufh_cooling_max_power_w,
             split_power_w=room_cfg.split_power_w,
             q_int_w=room_cfg.q_int_w,
+            loop_geometry=geometry,
         )
         rooms.append(sim_room)
 
@@ -103,6 +110,8 @@ def _build_simulator(scenario: SimScenario) -> BuildingSimulator:
         hp_max_power_w=scenario.building.hp_max_power_w,
         cwu_schedule=list(scenario.cwu_schedule),
         sensor_noise=noise,
+        weather_comp=scenario.weather_comp,
+        cooling_comp=scenario.cooling_comp,
     )
 
 

--- a/tests/unit/test_epic04_integration.py
+++ b/tests/unit/test_epic04_integration.py
@@ -36,6 +36,7 @@ from pumpahead.scenarios import (
 from pumpahead.sensor_noise import SensorNoise
 from pumpahead.simulated_room import SimulatedRoom
 from pumpahead.simulator import Actions, BuildingSimulator
+from pumpahead.ufh_loop import LoopGeometry
 from pumpahead.weather import WeatherPoint
 
 # ---------------------------------------------------------------------------
@@ -59,6 +60,10 @@ def _build_simulator_from_scenario(scenario: SimScenario) -> BuildingSimulator:
     rooms: list[SimulatedRoom] = []
     for room_cfg in scenario.building.rooms:
         model = RCModel(room_cfg.params, ModelOrder.THREE, dt=scenario.dt_seconds)
+        try:
+            geometry = LoopGeometry.from_room_config(room_cfg)
+        except ValueError:
+            geometry = None
         sim_room = SimulatedRoom(
             room_cfg.name,
             model,
@@ -66,6 +71,7 @@ def _build_simulator_from_scenario(scenario: SimScenario) -> BuildingSimulator:
             ufh_cooling_max_power_w=room_cfg.ufh_cooling_max_power_w,
             split_power_w=room_cfg.split_power_w,
             q_int_w=room_cfg.q_int_w,
+            loop_geometry=geometry,
         )
         rooms.append(sim_room)
 
@@ -79,6 +85,8 @@ def _build_simulator_from_scenario(scenario: SimScenario) -> BuildingSimulator:
         hp_max_power_w=scenario.building.hp_max_power_w,
         cwu_schedule=list(scenario.cwu_schedule),
         sensor_noise=noise,
+        weather_comp=scenario.weather_comp,
+        cooling_comp=scenario.cooling_comp,
     )
 
 

--- a/tests/unit/test_simulator_ufh_physical.py
+++ b/tests/unit/test_simulator_ufh_physical.py
@@ -1,0 +1,648 @@
+"""Unit tests for the physical UFH power distribution in BuildingSimulator.
+
+Covers ``BuildingSimulator._distribute_hp_power`` after the rewrite for
+issue #143 — now driven by ``pumpahead.ufh_loop.loop_power`` with a
+weather-compensation-derived ``T_supply`` instead of the legacy
+``valve * ufh_max_power_w`` proportional law.
+
+Three test classes:
+
+* ``TestPhysicalDistribution`` — rooms with explicit ``loop_geometry``.
+* ``TestFallbackShim`` — rooms without geometry (legacy path still
+  works; shim will be removed by issue #144).
+* ``TestDiagnostics`` — ``last_step_info`` surface exposes ``T_supply``
+  and per-room ``Q_floor`` correctly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pumpahead.model import ModelOrder, RCModel, RCParams
+from pumpahead.simulated_room import SimulatedRoom
+from pumpahead.simulator import (
+    Actions,
+    BuildingSimulator,
+    HeatPumpMode,
+)
+from pumpahead.ufh_loop import LoopGeometry
+from pumpahead.weather import SyntheticWeather
+from pumpahead.weather_comp import CoolingCompCurve, WeatherCompCurve
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _standard_params() -> RCParams:
+    """Return a 3R3C SISO RCParams instance used throughout the tests."""
+    return RCParams(
+        C_air=60_000,
+        C_slab=3_250_000,
+        C_wall=1_500_000,
+        R_sf=0.01,
+        R_wi=0.02,
+        R_wo=0.03,
+        R_ve=0.03,
+        R_ins=0.01,
+        f_conv=0.6,
+        f_rad=0.4,
+        T_ground=10.0,
+        has_split=False,
+    )
+
+
+def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
+    """Return a standard UFH loop geometry used throughout the tests."""
+    return LoopGeometry(
+        effective_pipe_length_m=130.0,
+        pipe_spacing_m=0.15,
+        pipe_diameter_outer_mm=16.0,
+        pipe_wall_thickness_mm=2.0,
+        area_m2=area_m2,
+    )
+
+
+def _make_room(
+    name: str,
+    *,
+    ufh_max_power_w: float = 5000.0,
+    ufh_cooling_max_power_w: float = 3000.0,
+    loop_geometry: LoopGeometry | None = None,
+) -> SimulatedRoom:
+    """Create a ``SimulatedRoom`` suitable for distributor tests."""
+    model = RCModel(_standard_params(), ModelOrder.THREE, dt=60.0)
+    return SimulatedRoom(
+        name,
+        model,
+        ufh_max_power_w=ufh_max_power_w,
+        ufh_cooling_max_power_w=ufh_cooling_max_power_w,
+        loop_geometry=loop_geometry,
+    )
+
+
+def _set_room_slab(room: SimulatedRoom, t_slab: float, t_air: float = 20.0) -> None:
+    """Set a room's thermal state so ``T_slab`` has a known value."""
+    room.set_initial_state(np.array([t_air, t_slab, t_air], dtype=np.float64))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def cold_weather() -> SyntheticWeather:
+    """Constant weather: T_out=-10 C."""
+    return SyntheticWeather.constant(T_out=-10.0, GHI=0.0)
+
+
+@pytest.fixture()
+def mild_weather() -> SyntheticWeather:
+    """Constant weather: T_out=+5 C."""
+    return SyntheticWeather.constant(T_out=5.0, GHI=0.0)
+
+
+@pytest.fixture()
+def hot_weather() -> SyntheticWeather:
+    """Constant weather: T_out=+32 C."""
+    return SyntheticWeather.constant(T_out=32.0, GHI=0.0)
+
+
+@pytest.fixture()
+def heating_curve() -> WeatherCompCurve:
+    """Heating curve: 30 C at t_out>=10 C, rising to 45 C at t_out<=-10 C."""
+    return WeatherCompCurve(
+        t_supply_base=30.0,
+        slope=0.75,
+        t_neutral=10.0,
+        t_supply_max=45.0,
+        t_supply_min=25.0,
+    )
+
+
+@pytest.fixture()
+def cooling_curve() -> CoolingCompCurve:
+    """Cooling curve: T_supply=12 C at mild, rising as t_out rises."""
+    return CoolingCompCurve(
+        t_supply_base=12.0,
+        slope=0.3,
+        t_neutral=25.0,
+        t_supply_max=22.0,
+        t_supply_min=8.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestPhysicalDistribution — rooms WITH geometry
+# ---------------------------------------------------------------------------
+
+
+class TestPhysicalDistribution:
+    """Tests for the physical loop_power path (rooms with geometry)."""
+
+    @pytest.mark.unit
+    def test_valve_zero_returns_zero_per_room(
+        self,
+        cold_weather: SyntheticWeather,
+    ) -> None:
+        """valve=0 -> allocated power is 0 regardless of T_supply."""
+        geometry = _standard_geometry()
+        rooms = [
+            _make_room("r0", loop_geometry=geometry),
+            _make_room("r1", loop_geometry=geometry),
+        ]
+        for r in rooms:
+            _set_room_slab(r, t_slab=22.0)
+
+        sim = BuildingSimulator(
+            rooms,
+            cold_weather,
+            hp_mode=HeatPumpMode.HEATING,
+            hp_max_power_w=10_000.0,
+        )
+
+        actions = {r.name: Actions(valve_position=0.0) for r in rooms}
+        allocated = sim._distribute_hp_power(actions)
+
+        assert allocated["r0"] == 0.0
+        assert allocated["r1"] == 0.0
+
+    @pytest.mark.unit
+    def test_valve_one_high_supply_high_power(
+        self,
+        cold_weather: SyntheticWeather,
+    ) -> None:
+        """valve=100% with a high T_supply yields strictly positive power."""
+        geometry = _standard_geometry()
+        room = _make_room("r0", loop_geometry=geometry)
+        _set_room_slab(room, t_slab=22.0)
+
+        # No weather_comp -> fallback 35 C in heating.
+        sim = BuildingSimulator(
+            [room],
+            cold_weather,
+            hp_mode=HeatPumpMode.HEATING,
+            hp_max_power_w=10_000.0,
+        )
+
+        allocated = sim._distribute_hp_power(
+            {"r0": Actions(valve_position=100.0)},
+        )
+
+        assert allocated["r0"] > 0.0
+
+    @pytest.mark.unit
+    def test_higher_supply_higher_power(
+        self,
+        cold_weather: SyntheticWeather,
+    ) -> None:
+        """A higher T_supply (via heating curve) gives strictly more power."""
+        geometry = _standard_geometry()
+
+        # Curve A: moderate supply.
+        curve_low = WeatherCompCurve(
+            t_supply_base=28.0,
+            slope=0.0,
+            t_neutral=10.0,
+            t_supply_max=40.0,
+            t_supply_min=25.0,
+        )
+        # Curve B: aggressive supply.
+        curve_high = WeatherCompCurve(
+            t_supply_base=40.0,
+            slope=0.0,
+            t_neutral=10.0,
+            t_supply_max=45.0,
+            t_supply_min=25.0,
+        )
+
+        def _allocate(curve: WeatherCompCurve) -> float:
+            room = _make_room("r0", loop_geometry=geometry)
+            _set_room_slab(room, t_slab=22.0)
+            sim = BuildingSimulator(
+                [room],
+                cold_weather,
+                hp_mode=HeatPumpMode.HEATING,
+                hp_max_power_w=100_000.0,  # unconstrained
+                weather_comp=curve,
+            )
+            allocated = sim._distribute_hp_power(
+                {"r0": Actions(valve_position=100.0)},
+            )
+            return allocated["r0"]
+
+        q_low = _allocate(curve_low)
+        q_high = _allocate(curve_high)
+
+        assert q_high > q_low
+        assert q_low > 0.0
+
+    @pytest.mark.unit
+    def test_cold_outdoor_raises_supply_via_curve(
+        self,
+        heating_curve: WeatherCompCurve,
+    ) -> None:
+        """Colder outdoor -> curve raises T_supply -> more floor power."""
+        geometry = _standard_geometry()
+
+        def _allocate(t_out: float) -> float:
+            weather = SyntheticWeather.constant(T_out=t_out, GHI=0.0)
+            room = _make_room("r0", loop_geometry=geometry)
+            _set_room_slab(room, t_slab=22.0)
+            sim = BuildingSimulator(
+                [room],
+                weather,
+                hp_mode=HeatPumpMode.HEATING,
+                hp_max_power_w=100_000.0,  # unconstrained
+                weather_comp=heating_curve,
+            )
+            return sim._distribute_hp_power(
+                {"r0": Actions(valve_position=100.0)},
+            )["r0"]
+
+        q_mild = _allocate(5.0)
+        q_cold = _allocate(-15.0)
+
+        assert q_cold > q_mild
+        assert q_mild > 0.0
+
+    @pytest.mark.unit
+    def test_hp_capacity_limit_scales_proportionally(
+        self,
+        cold_weather: SyntheticWeather,
+    ) -> None:
+        """Total physical demand above HP capacity -> proportional scale."""
+        geometry = _standard_geometry()
+        rooms = [_make_room(f"r{i}", loop_geometry=geometry) for i in range(4)]
+        for r in rooms:
+            _set_room_slab(r, t_slab=22.0)
+
+        # Unconstrained run to measure raw demand.
+        sim_unlimited = BuildingSimulator(
+            [_make_room(f"r{i}", loop_geometry=geometry) for i in range(4)],
+            cold_weather,
+            hp_mode=HeatPumpMode.HEATING,
+        )
+        for r in sim_unlimited._rooms:
+            _set_room_slab(r, t_slab=22.0)
+
+        actions = {f"r{i}": Actions(valve_position=100.0) for i in range(4)}
+        raw = sim_unlimited._distribute_hp_power(actions)
+        raw_total = sum(raw.values())
+        assert raw_total > 0.0
+
+        # Now run with HP capped well below the raw total.
+        cap = raw_total / 2.0
+        sim = BuildingSimulator(
+            rooms,
+            cold_weather,
+            hp_mode=HeatPumpMode.HEATING,
+            hp_max_power_w=cap,
+        )
+        allocated = sim._distribute_hp_power(actions)
+
+        assert sum(allocated.values()) == pytest.approx(cap)
+        # Ratios of the allocated values must match ratios of raw demands.
+        for i in range(4):
+            expected = raw[f"r{i}"] * cap / raw_total
+            assert allocated[f"r{i}"] == pytest.approx(expected, rel=1e-9)
+
+    @pytest.mark.unit
+    def test_cooling_returns_negative_values(
+        self,
+        hot_weather: SyntheticWeather,
+    ) -> None:
+        """Cooling mode with a warm slab returns negative Q_floor."""
+        geometry = _standard_geometry()
+        room = _make_room("r0", loop_geometry=geometry)
+        _set_room_slab(room, t_slab=24.0)
+
+        sim = BuildingSimulator(
+            [room],
+            hot_weather,
+            hp_mode=HeatPumpMode.COOLING,
+            hp_max_power_w=10_000.0,
+        )
+
+        allocated = sim._distribute_hp_power(
+            {"r0": Actions(valve_position=100.0)},
+        )
+        assert allocated["r0"] < 0.0
+
+    @pytest.mark.unit
+    def test_cooling_hp_capacity_limit(
+        self,
+        hot_weather: SyntheticWeather,
+        cooling_curve: CoolingCompCurve,
+    ) -> None:
+        """In cooling mode the absolute total respects hp_max_power_w."""
+        geometry = _standard_geometry()
+        rooms = [_make_room(f"r{i}", loop_geometry=geometry) for i in range(4)]
+        for r in rooms:
+            _set_room_slab(r, t_slab=24.0)
+
+        actions = {f"r{i}": Actions(valve_position=100.0) for i in range(4)}
+
+        # Raw demand (unconstrained).
+        sim_unlimited = BuildingSimulator(
+            [_make_room(f"r{i}", loop_geometry=geometry) for i in range(4)],
+            hot_weather,
+            hp_mode=HeatPumpMode.COOLING,
+            cooling_comp=cooling_curve,
+        )
+        for r in sim_unlimited._rooms:
+            _set_room_slab(r, t_slab=24.0)
+        raw = sim_unlimited._distribute_hp_power(actions)
+        raw_abs_total = sum(abs(d) for d in raw.values())
+        assert raw_abs_total > 0.0
+
+        cap = raw_abs_total / 2.0
+        sim = BuildingSimulator(
+            rooms,
+            hot_weather,
+            hp_mode=HeatPumpMode.COOLING,
+            hp_max_power_w=cap,
+            cooling_comp=cooling_curve,
+        )
+        allocated = sim._distribute_hp_power(actions)
+
+        assert sum(abs(d) for d in allocated.values()) == pytest.approx(cap)
+        # All entries must remain non-positive (cooling sign convention).
+        for name in allocated:
+            assert allocated[name] <= 0.0
+
+    @pytest.mark.unit
+    def test_hp_off_returns_zero_and_no_supply(
+        self,
+        cold_weather: SyntheticWeather,
+    ) -> None:
+        """HP OFF short-circuits to zero and clears ``t_supply_c``."""
+        geometry = _standard_geometry()
+        rooms = [_make_room(f"r{i}", loop_geometry=geometry) for i in range(3)]
+        sim = BuildingSimulator(
+            rooms,
+            cold_weather,
+            hp_mode=HeatPumpMode.OFF,
+            hp_max_power_w=10_000.0,
+        )
+
+        allocated = sim._distribute_hp_power(
+            {r.name: Actions(valve_position=100.0) for r in rooms},
+        )
+
+        for name, v in allocated.items():
+            assert v == 0.0, f"{name} should be 0 when HP is OFF"
+        assert sim.last_step_info["t_supply_c"] is None
+
+    @pytest.mark.unit
+    def test_axiom_3_wrong_direction_returns_zero(
+        self,
+        cold_weather: SyntheticWeather,
+    ) -> None:
+        """HEATING with T_slab >= T_supply -> loop_power=0 (Axiom #3)."""
+        geometry = _standard_geometry()
+        room = _make_room("r0", loop_geometry=geometry)
+        # T_slab at 40 C is hotter than the fallback 35 C supply.
+        _set_room_slab(room, t_slab=40.0)
+
+        sim = BuildingSimulator(
+            [room],
+            cold_weather,
+            hp_mode=HeatPumpMode.HEATING,
+            hp_max_power_w=10_000.0,
+        )
+
+        allocated = sim._distribute_hp_power(
+            {"r0": Actions(valve_position=100.0)},
+        )
+
+        assert allocated["r0"] == 0.0
+
+    @pytest.mark.unit
+    def test_compute_t_supply_off_returns_zero(
+        self,
+        cold_weather: SyntheticWeather,
+    ) -> None:
+        """_compute_t_supply returns 0.0 when HP is OFF (defensive path)."""
+        geometry = _standard_geometry()
+        room = _make_room("r0", loop_geometry=geometry)
+        sim = BuildingSimulator(
+            [room],
+            cold_weather,
+            hp_mode=HeatPumpMode.OFF,
+        )
+        # Directly exercise the defensive branch — callers of
+        # _distribute_hp_power short-circuit OFF before calling this,
+        # but the helper still has to return a finite value.
+        assert sim._compute_t_supply(-5.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# TestFallbackShim — rooms WITHOUT geometry (legacy path)
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackShim:
+    """Tests for the legacy valve * ufh_max_power_w shim path."""
+
+    @pytest.mark.unit
+    def test_legacy_heating_without_geometry(
+        self,
+        cold_weather: SyntheticWeather,
+    ) -> None:
+        """Heating without geometry -> valve * ufh_max_power_w."""
+        # No loop_geometry -> shim path.
+        rooms = [
+            _make_room("r0", ufh_max_power_w=4000.0, loop_geometry=None),
+            _make_room("r1", ufh_max_power_w=4000.0, loop_geometry=None),
+        ]
+        sim = BuildingSimulator(
+            rooms,
+            cold_weather,
+            hp_mode=HeatPumpMode.HEATING,
+            hp_max_power_w=20_000.0,
+        )
+
+        allocated = sim._distribute_hp_power(
+            {
+                "r0": Actions(valve_position=50.0),
+                "r1": Actions(valve_position=100.0),
+            },
+        )
+
+        assert allocated["r0"] == pytest.approx(0.5 * 4000.0)
+        assert allocated["r1"] == pytest.approx(1.0 * 4000.0)
+
+    @pytest.mark.unit
+    def test_legacy_cooling_without_geometry(
+        self,
+        hot_weather: SyntheticWeather,
+    ) -> None:
+        """Cooling without geometry -> negative valve * ufh_cooling_max_power_w."""
+        rooms = [
+            _make_room(
+                "r0",
+                ufh_cooling_max_power_w=2000.0,
+                loop_geometry=None,
+            ),
+            _make_room(
+                "r1",
+                ufh_cooling_max_power_w=2000.0,
+                loop_geometry=None,
+            ),
+        ]
+        sim = BuildingSimulator(
+            rooms,
+            hot_weather,
+            hp_mode=HeatPumpMode.COOLING,
+            hp_max_power_w=20_000.0,
+        )
+
+        allocated = sim._distribute_hp_power(
+            {
+                "r0": Actions(valve_position=50.0),
+                "r1": Actions(valve_position=100.0),
+            },
+        )
+
+        assert allocated["r0"] == pytest.approx(-0.5 * 2000.0)
+        assert allocated["r1"] == pytest.approx(-1.0 * 2000.0)
+
+    @pytest.mark.unit
+    def test_mixed_rooms_with_and_without_geometry(
+        self,
+        cold_weather: SyntheticWeather,
+    ) -> None:
+        """Simulator accepts a mix of physical and legacy rooms."""
+        geometry = _standard_geometry()
+        room_physical = _make_room(
+            "physical",
+            loop_geometry=geometry,
+        )
+        _set_room_slab(room_physical, t_slab=22.0)
+        room_legacy = _make_room(
+            "legacy",
+            ufh_max_power_w=3000.0,
+            loop_geometry=None,
+        )
+
+        sim = BuildingSimulator(
+            [room_physical, room_legacy],
+            cold_weather,
+            hp_mode=HeatPumpMode.HEATING,
+            hp_max_power_w=100_000.0,  # unconstrained
+        )
+
+        allocated = sim._distribute_hp_power(
+            {
+                "physical": Actions(valve_position=100.0),
+                "legacy": Actions(valve_position=50.0),
+            },
+        )
+
+        # Legacy room: exact shim result.
+        assert allocated["legacy"] == pytest.approx(0.5 * 3000.0)
+        # Physical room: positive, finite, not tied to ufh_max_power_w.
+        assert allocated["physical"] > 0.0
+        assert np.isfinite(allocated["physical"])
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnostics — last_step_info surface
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnostics:
+    """Tests for BuildingSimulator.last_step_info."""
+
+    @pytest.mark.unit
+    def test_initial_state_is_empty(
+        self,
+        cold_weather: SyntheticWeather,
+    ) -> None:
+        """Before any step, diagnostics are empty / None."""
+        rooms = [
+            _make_room("r0", loop_geometry=_standard_geometry()),
+        ]
+        sim = BuildingSimulator(
+            rooms,
+            cold_weather,
+            hp_mode=HeatPumpMode.HEATING,
+        )
+
+        info = sim.last_step_info
+        assert info["t_supply_c"] is None
+        assert info["q_floor_w"] == {}
+        assert info["hp_mode"] == HeatPumpMode.HEATING
+
+    @pytest.mark.unit
+    def test_populated_after_step_all(
+        self,
+        cold_weather: SyntheticWeather,
+        heating_curve: WeatherCompCurve,
+    ) -> None:
+        """After step_all, diagnostics reflect the last distribution."""
+        geometry = _standard_geometry()
+        rooms = [_make_room(f"r{i}", loop_geometry=geometry) for i in range(2)]
+        for r in rooms:
+            _set_room_slab(r, t_slab=22.0)
+
+        sim = BuildingSimulator(
+            rooms,
+            cold_weather,
+            hp_mode=HeatPumpMode.HEATING,
+            hp_max_power_w=100_000.0,
+            weather_comp=heating_curve,
+        )
+
+        actions = {r.name: Actions(valve_position=100.0) for r in rooms}
+        sim.step_all(actions)
+
+        info = sim.last_step_info
+
+        # T_supply matches the curve at T_out=-10 C.
+        expected = heating_curve.t_supply(-10.0)
+        assert info["t_supply_c"] == pytest.approx(expected)
+
+        q = info["q_floor_w"]
+        assert isinstance(q, dict)
+        assert set(q.keys()) == {"r0", "r1"}
+        for name in q:
+            assert q[name] > 0.0
+
+        assert info["hp_mode"] == HeatPumpMode.HEATING
+
+    @pytest.mark.unit
+    def test_last_step_info_is_defensive_copy(
+        self,
+        cold_weather: SyntheticWeather,
+    ) -> None:
+        """Mutating q_floor_w in the returned dict does not affect state."""
+        geometry = _standard_geometry()
+        rooms = [_make_room("r0", loop_geometry=geometry)]
+        _set_room_slab(rooms[0], t_slab=22.0)
+
+        sim = BuildingSimulator(
+            rooms,
+            cold_weather,
+            hp_mode=HeatPumpMode.HEATING,
+            hp_max_power_w=10_000.0,
+        )
+        sim.step_all({"r0": Actions(valve_position=100.0)})
+
+        info1 = sim.last_step_info
+        q1 = info1["q_floor_w"]
+        assert isinstance(q1, dict)
+        original = q1["r0"]
+
+        # Mutate the returned dict.
+        q1["r0"] = -999.0
+        q1["injected"] = 42.0
+
+        info2 = sim.last_step_info
+        q2 = info2["q_floor_w"]
+        assert isinstance(q2, dict)
+        assert q2["r0"] == pytest.approx(original)
+        assert "injected" not in q2


### PR DESCRIPTION
Closes #143

## Summary
Rewrites `BuildingSimulator._distribute_hp_power` to drive per-room floor heat output through the EN 1264 physical model (`pumpahead.ufh_loop.loop_power`) with `T_supply` derived from the weather-compensation curves. Preserves legacy `valve * ufh_max_power_w` behaviour as a transition shim for rooms without `loop_geometry` (full removal tracked in #144).

## Key changes
- `pumpahead/simulator.py`: new `_compute_t_supply` helper, `last_step_info` property with per-room `Q_floor` + current `T_supply`, kw-only `weather_comp`/`cooling_comp` constructor params, fallback constants `_FALLBACK_T_SUPPLY_HEATING_C=35.0` / `_FALLBACK_T_SUPPLY_COOLING_C=18.0`.
- `pumpahead/simulated_room.py`: optional `loop_geometry: LoopGeometry | None` ctor param with read-only property.
- `pumpahead/ab_testing.py`, `tests/simulation/conftest.py`, `tests/unit/test_epic04_integration.py`: thread `LoopGeometry.from_room_config(...)` + scenario curves through all three simulator builders.
- `tests/unit/test_simulator_ufh_physical.py` (new, 16 tests): physical distribution, fallback shim, diagnostics.

## Test plan
- [x] `pytest tests/unit/test_simulator_ufh_physical.py` — 16 passed
- [x] Wider unit sweep (simulator/controller/cooling/CWU/epic integrations/AB): 369 passed
- [x] Simulation smoke: `cold_snap` + `full_year_2025` passed
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` clean on changed files
- [ ] CI full unit suite (~2073 tests) — verified by CI on PR