### PR TITLE
Issue #144: Remove ufh_max_power_w and ufh_cooling_max_power_w from RoomConfig

### DIFF
--- a/pumpahead/ab_testing.py
+++ b/pumpahead/ab_testing.py
@@ -278,16 +278,16 @@ class MPCAdapter:
 
             # Build RC model at MPC dt.
             # Scale B matrix so that u=1 represents full UFH power
-            # (ufh_max_power_w Watts), not 1 Watt.  Without this
-            # scaling the MPC thinks its maximum heating power is 1 W
-            # and always saturates at u=1, causing overshoot when the
-            # adapter converts u_floor_0 to valve percentage.
+            # (nominal_ufh_power_heating_w Watts), not 1 Watt.  Without
+            # this scaling the MPC thinks its maximum heating power is
+            # 1 W and always saturates at u=1, causing overshoot when
+            # the adapter converts u_floor_0 to valve percentage.
             mpc_model = RCModel(
                 room_cfg.params,
                 ModelOrder.THREE,
                 dt=float(self._mpc_dt_seconds),
             )
-            power_scale = room_cfg.ufh_max_power_w
+            power_scale = room_cfg.nominal_ufh_power_heating_w
             mpc_model._B_c = mpc_model._B_c * power_scale  # noqa: SLF001
             mpc_model._discretize()  # noqa: SLF001
 
@@ -584,15 +584,12 @@ class ABTestRunner:
         rooms: list[SimulatedRoom] = []
         for room_cfg in scenario.building.rooms:
             model = RCModel(room_cfg.params, ModelOrder.THREE, dt=scenario.dt_seconds)
-            try:
-                geometry = LoopGeometry.from_room_config(room_cfg)
-            except ValueError:
-                # Room has no pipe geometry — fall back to legacy shim.
-                geometry = None
+            # Post-#144 every room must carry pipe geometry — propagate
+            # the ``ValueError`` if any caller forgets to set it.
+            geometry = LoopGeometry.from_room_config(room_cfg)
             sim_room = SimulatedRoom(
                 room_cfg.name,
                 model,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
                 split_power_w=room_cfg.split_power_w,
                 q_int_w=room_cfg.q_int_w,
                 loop_geometry=geometry,
@@ -676,7 +673,7 @@ class ABTestRunner:
         metrics = SimMetrics.from_log(
             room_log,
             setpoint=setpoint,
-            ufh_max_power_w=first_room.ufh_max_power_w,
+            ufh_nominal_power_w=first_room.nominal_ufh_power_heating_w,
             split_power_w=first_room.split_power_w,
             dt_minutes=1,
         )

--- a/pumpahead/building_profiles.py
+++ b/pumpahead/building_profiles.py
@@ -48,6 +48,15 @@ __all__ = [
 
 _REF_AREA = 20.0  # Reference room area [m^2] for scaling
 
+# Modern bungalow UFH pipe spacing [m].  The real salon loop is
+# documented at 96 m of pipe in 36.28 m² ⇒ ~0.15 m centre-to-centre
+# (standard residential practice).  Reused across all 13 rooms.
+_MODERN_BUNGALOW_PIPE_SPACING_M: float = 0.15
+
+# Fallback pipe spacing [m] for single-room parametric profiles
+# (well_insulated, leaky_old_house, thin_screed, heavy_construction).
+_SINGLE_ROOM_PIPE_SPACING_M: float = 0.20
+
 # Defaults calibrated to a modern, heavily insulated single-storey house
 # (30 cm mineral wool walls, 20 cm ceiling wool, 7 cm wet screed) so that a
 # ~155 m^2 building loses ~4.5 kW at design ΔT=40 K (T_in=20, T_out=-20).
@@ -145,11 +154,6 @@ _Q_INT_WC = 10.0
 _Q_INT_ENTRY = 10.0
 
 
-def _ufh_max(area_m2: float) -> float:
-    """UFH max thermal power [W] sized at ~100 W/m² (T_floor≈30 °C)."""
-    return 100.0 * area_m2
-
-
 MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
     # garderoba — 7.40 m^2, 1 loop, no windows
     RoomConfig(
@@ -157,8 +161,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         area_m2=7.40,
         params=_make_3r3c_params(area_m2=7.40),
         windows=(),
-        ufh_max_power_w=_ufh_max(7.40),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(7.40),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_CLOSET,
     ),
@@ -170,8 +173,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         windows=(
             WindowConfig(orientation=Orientation.SOUTH, area_m2=2.5, g_value=0.6),
         ),
-        ufh_max_power_w=_ufh_max(12.68),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(12.68),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_BEDROOM,
     ),
@@ -181,8 +183,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         area_m2=12.12,
         params=_make_3r3c_params(area_m2=12.12),
         windows=(),
-        ufh_max_power_w=_ufh_max(12.12),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(12.12),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_HALL,
     ),
@@ -195,8 +196,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         windows=(
             WindowConfig(orientation=Orientation.NORTH, area_m2=0.5, g_value=0.6),
         ),
-        ufh_max_power_w=_ufh_max(8.90),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(8.90),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_BATH,
     ),
@@ -206,8 +206,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         area_m2=14.33,
         params=_make_3r3c_params(area_m2=14.33),
         windows=(WindowConfig(orientation=Orientation.EAST, area_m2=2.0, g_value=0.6),),
-        ufh_max_power_w=_ufh_max(14.33),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(14.33),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_CHILD,
     ),
@@ -217,8 +216,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         area_m2=11.65,
         params=_make_3r3c_params(area_m2=11.65),
         windows=(WindowConfig(orientation=Orientation.EAST, area_m2=2.0, g_value=0.6),),
-        ufh_max_power_w=_ufh_max(11.65),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(11.65),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_CHILD,
     ),
@@ -228,8 +226,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         area_m2=5.0,
         params=_make_3r3c_params(area_m2=5.0),
         windows=(),
-        ufh_max_power_w=_ufh_max(5.0),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(5.0),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_HALL,
     ),
@@ -241,8 +238,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         windows=(
             WindowConfig(orientation=Orientation.NORTH, area_m2=1.0, g_value=0.6),
         ),
-        ufh_max_power_w=_ufh_max(5.05),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(5.05),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_ENTRY,
     ),
@@ -255,8 +251,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
             WindowConfig(orientation=Orientation.SOUTH, area_m2=5.0, g_value=0.6),
             WindowConfig(orientation=Orientation.WEST, area_m2=3.0, g_value=0.6),
         ),
-        ufh_max_power_w=_ufh_max(36.28),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(36.28),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_SALON,
     ),
@@ -266,8 +261,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         area_m2=13.59,
         params=_make_3r3c_params(area_m2=13.59),
         windows=(WindowConfig(orientation=Orientation.EAST, area_m2=2.0, g_value=0.6),),
-        ufh_max_power_w=_ufh_max(13.59),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(13.59),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_KITCHEN,
     ),
@@ -279,8 +273,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         windows=(
             WindowConfig(orientation=Orientation.NORTH, area_m2=1.5, g_value=0.6),
         ),
-        ufh_max_power_w=_ufh_max(13.0),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(13.0),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_OFFICE,
     ),
@@ -292,8 +285,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         windows=(
             WindowConfig(orientation=Orientation.NORTH, area_m2=1.5, g_value=0.6),
         ),
-        ufh_max_power_w=_ufh_max(12.62),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(12.62),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_OFFICE,
     ),
@@ -303,8 +295,7 @@ MODERN_BUNGALOW_ROOMS: tuple[RoomConfig, ...] = (
         area_m2=5.49,
         params=_make_3r3c_params(area_m2=5.49),
         windows=(),
-        ufh_max_power_w=_ufh_max(5.49),
-        ufh_cooling_max_power_w=0.6 * _ufh_max(5.49),
+        pipe_spacing_m=_MODERN_BUNGALOW_PIPE_SPACING_M,
         ufh_loops=1,
         q_int_w=_Q_INT_WC,
     ),
@@ -392,9 +383,11 @@ def _add_split(room: RoomConfig) -> RoomConfig:
         windows=room.windows,
         has_split=True,
         split_power_w=_SPLIT_POWER_BY_ROOM[room.name],
-        ufh_max_power_w=room.ufh_max_power_w,
-        ufh_cooling_max_power_w=room.ufh_cooling_max_power_w,
         ufh_loops=room.ufh_loops,
+        pipe_length_m=room.pipe_length_m,
+        pipe_spacing_m=room.pipe_spacing_m,
+        pipe_diameter_outer_mm=room.pipe_diameter_outer_mm,
+        pipe_wall_thickness_mm=room.pipe_wall_thickness_mm,
         q_int_w=room.q_int_w,
     )
 
@@ -428,8 +421,8 @@ def modern_bungalow_with_splits() -> BuildingParams:
 # to track the 24 °C setpoint against the 20 °C house-wide target.  This
 # profile mirrors the real wiring: only ``lazienka`` is modified, gaining a
 # ``has_split=True`` auxiliary that is actually a heating-only source
-# (``auxiliary_type="heater"``, ``ufh_cooling_max_power_w=0.0``).  All other
-# rooms are identical to ``modern_bungalow``.
+# (``auxiliary_type="heater"``).  All other rooms are identical to
+# ``modern_bungalow``.
 
 
 _BATHROOM_HEATER_POWER_W = 300.0
@@ -440,8 +433,8 @@ def _lazienka_with_heater(room: RoomConfig) -> RoomConfig:
 
     Only the ``lazienka`` room is modified.  The new RoomConfig has
     ``has_split=True`` (to reuse the SplitCoordinator pipeline),
-    ``split_power_w=300.0`` W, ``auxiliary_type="heater"`` and
-    ``ufh_cooling_max_power_w=0.0`` (heater rooms must not cool).
+    ``split_power_w=300.0`` W, and ``auxiliary_type="heater"`` so the
+    controller forces ``SplitMode.OFF`` in cooling mode (Axiom #3).
     The underlying ``RCParams`` is rebuilt with ``has_split=True``.
 
     Args:
@@ -475,9 +468,11 @@ def _lazienka_with_heater(room: RoomConfig) -> RoomConfig:
         windows=room.windows,
         has_split=True,
         split_power_w=_BATHROOM_HEATER_POWER_W,
-        ufh_max_power_w=room.ufh_max_power_w,
-        ufh_cooling_max_power_w=0.0,
         ufh_loops=room.ufh_loops,
+        pipe_length_m=room.pipe_length_m,
+        pipe_spacing_m=room.pipe_spacing_m,
+        pipe_diameter_outer_mm=room.pipe_diameter_outer_mm,
+        pipe_wall_thickness_mm=room.pipe_wall_thickness_mm,
         q_int_w=room.q_int_w,
         auxiliary_type="heater",
     )
@@ -491,9 +486,7 @@ def modern_bungalow_with_bathroom_heater() -> BuildingParams:
     (``auxiliary_type="heater"``, 300 W).  The heater reuses the
     ``SplitCoordinator`` pipeline but the controller forces
     ``SplitMode.OFF`` for heater rooms in cooling mode so the heater
-    never opposes the HP mode (Axiom #3).  Bathroom floor cooling is
-    disabled (``ufh_cooling_max_power_w=0.0``) consistent with the
-    real wiring.
+    never opposes the HP mode (Axiom #3).
 
     All other 12 rooms are identical to ``modern_bungalow``.
 
@@ -546,8 +539,7 @@ def well_insulated() -> BuildingParams:
         ),
         has_split=False,
         split_power_w=0.0,
-        ufh_max_power_w=4000.0,
-        ufh_cooling_max_power_w=2400.0,
+        pipe_spacing_m=_SINGLE_ROOM_PIPE_SPACING_M,
         ufh_loops=2,
         q_int_w=100.0,
     )
@@ -596,8 +588,7 @@ def leaky_old_house() -> BuildingParams:
         ),
         has_split=False,
         split_power_w=0.0,
-        ufh_max_power_w=6000.0,
-        ufh_cooling_max_power_w=3600.0,
+        pipe_spacing_m=_SINGLE_ROOM_PIPE_SPACING_M,
         ufh_loops=2,
         q_int_w=100.0,
     )
@@ -646,8 +637,7 @@ def thin_screed() -> BuildingParams:
         ),
         has_split=False,
         split_power_w=0.0,
-        ufh_max_power_w=4000.0,
-        ufh_cooling_max_power_w=2400.0,
+        pipe_spacing_m=_SINGLE_ROOM_PIPE_SPACING_M,
         ufh_loops=2,
         q_int_w=100.0,
     )
@@ -696,8 +686,7 @@ def heavy_construction() -> BuildingParams:
         ),
         has_split=False,
         split_power_w=0.0,
-        ufh_max_power_w=5000.0,
-        ufh_cooling_max_power_w=3000.0,
+        pipe_spacing_m=_SINGLE_ROOM_PIPE_SPACING_M,
         ufh_loops=2,
         q_int_w=100.0,
     )

--- a/pumpahead/config.py
+++ b/pumpahead/config.py
@@ -88,11 +88,6 @@ class RoomConfig:
         has_split: Whether this room has a split/AC unit.
         split_power_w: Maximum split power [W] (> 0 when has_split=True,
             must be 0.0 when has_split=False).
-        ufh_max_power_w: Maximum UFH power [W] (must be > 0).
-        ufh_cooling_max_power_w: Maximum UFH cooling power [W]
-            (must be >= 0).  Typically ~60 % of heating power due to
-            asymmetric floor heat transfer.  Defaults to 0.0 (no floor
-            cooling capability).
         ufh_loops: Number of UFH loops (must be >= 1).
         pipe_length_m: Total measured pipe length [m] (must be > 0 when
             set).  Mutually exclusive with ``pipe_spacing_m``: provide
@@ -111,9 +106,7 @@ class RoomConfig:
             is only active in heating mode — the controller forces
             ``SplitMode.OFF`` in cooling mode regardless of error.
             ``"heater"`` requires ``has_split=True`` (to reuse the
-            ``SplitCoordinator`` pipeline) and
-            ``ufh_cooling_max_power_w == 0.0`` (heater rooms must not
-            cool via the floor either).
+            ``SplitCoordinator`` pipeline).
     """
 
     name: str
@@ -122,8 +115,6 @@ class RoomConfig:
     windows: tuple[WindowConfig, ...] = ()
     has_split: bool = False
     split_power_w: float = 0.0
-    ufh_max_power_w: float = 5000.0
-    ufh_cooling_max_power_w: float = 0.0
     ufh_loops: int = 1
     pipe_length_m: float | None = None
     pipe_spacing_m: float | None = None
@@ -153,15 +144,6 @@ class RoomConfig:
             msg = (
                 f"split_power_w must be 0.0 when has_split=False, "
                 f"got {self.split_power_w}"
-            )
-            raise ValueError(msg)
-        if self.ufh_max_power_w <= 0:
-            msg = f"ufh_max_power_w must be > 0, got {self.ufh_max_power_w}"
-            raise ValueError(msg)
-        if self.ufh_cooling_max_power_w < 0:
-            msg = (
-                f"ufh_cooling_max_power_w must be >= 0, "
-                f"got {self.ufh_cooling_max_power_w}"
             )
             raise ValueError(msg)
         if self.ufh_loops < 1:
@@ -212,20 +194,12 @@ class RoomConfig:
                 f"got '{self.auxiliary_type}'"
             )
             raise ValueError(msg)
-        if self.auxiliary_type == "heater":
-            if not self.has_split:
-                msg = (
-                    "auxiliary_type='heater' requires has_split=True "
-                    "(heater rooms reuse the split coordinator pipeline)"
-                )
-                raise ValueError(msg)
-            if self.ufh_cooling_max_power_w != 0.0:
-                msg = (
-                    f"auxiliary_type='heater' requires "
-                    f"ufh_cooling_max_power_w=0.0, "
-                    f"got {self.ufh_cooling_max_power_w}"
-                )
-                raise ValueError(msg)
+        if self.auxiliary_type == "heater" and not self.has_split:
+            msg = (
+                "auxiliary_type='heater' requires has_split=True "
+                "(heater rooms reuse the split coordinator pipeline)"
+            )
+            raise ValueError(msg)
 
     @property
     def effective_pipe_length_m(self) -> float:
@@ -246,6 +220,57 @@ class RoomConfig:
         raise ValueError(
             f"RoomConfig '{self.name}': pipe geometry not configured — "
             f"set pipe_length_m or pipe_spacing_m"
+        )
+
+    @property
+    def nominal_ufh_power_heating_w(self) -> float:
+        """Nominal UFH heating power at T_supply=35 C, T_slab=20 C [W].
+
+        Derived from ``LoopGeometry.from_room_config(self)`` and the EN
+        1264 reduced formula (``pumpahead.ufh_loop.loop_power``).  The
+        chosen nominal conditions sit safely on the heating side of
+        Axiom #3 (T_supply > T_slab), so the result is always positive.
+
+        Returns:
+            Positive float representing the nominal heating capacity [W].
+
+        Raises:
+            ValueError: If pipe geometry is not configured (see
+                ``effective_pipe_length_m``).
+        """
+        # Local import to avoid a circular dependency with
+        # ``pumpahead.ufh_loop`` (which imports ``RoomConfig`` under
+        # ``TYPE_CHECKING``).
+        from pumpahead.ufh_loop import LoopGeometry, loop_power
+
+        geom = LoopGeometry.from_room_config(self)
+        return loop_power(t_supply=35.0, t_slab=20.0, geometry=geom, mode="heating")
+
+    @property
+    def nominal_ufh_power_cooling_w(self) -> float:
+        """Nominal UFH cooling power magnitude at T_supply=18 C, T_slab=25 C [W].
+
+        Derived from ``LoopGeometry.from_room_config(self)`` and the EN
+        1264 reduced formula (``pumpahead.ufh_loop.loop_power``).  The
+        chosen nominal conditions sit safely on the cooling side of
+        Axiom #3 (T_supply < T_slab).  ``loop_power`` returns a negative
+        value in cooling mode; this property returns ``abs(...)`` so the
+        result is always a positive magnitude in Watts.
+
+        Returns:
+            Positive float representing the nominal cooling magnitude [W].
+
+        Raises:
+            ValueError: If pipe geometry is not configured (see
+                ``effective_pipe_length_m``).
+        """
+        # Local import to avoid a circular dependency with
+        # ``pumpahead.ufh_loop``.
+        from pumpahead.ufh_loop import LoopGeometry, loop_power
+
+        geom = LoopGeometry.from_room_config(self)
+        return abs(
+            loop_power(t_supply=18.0, t_slab=25.0, geometry=geom, mode="cooling")
         )
 
 

--- a/pumpahead/controller.py
+++ b/pumpahead/controller.py
@@ -434,8 +434,10 @@ class PumpAheadController:
             if is_heater_room and is_cooling:
                 # Short-circuit: no split decision, no valve_floor_boost,
                 # no runtime sample.  Room is UFH-only in cooling mode
-                # (ufh_cooling_max_power_w=0.0 is enforced upstream by
-                # RoomConfig validation, so valve cooling is also zero).
+                # (the auxiliary_type="heater" marker is the enforcement
+                # mechanism — see issue #144; physical cooling via the
+                # floor loop is still theoretically possible if the
+                # valve opens, but the controller keeps the heater off).
                 actions[name] = Actions(
                     valve_position=valve,
                     split_mode=SplitMode.OFF,

--- a/pumpahead/metrics.py
+++ b/pumpahead/metrics.py
@@ -122,7 +122,7 @@ class SimMetrics:
         setpoint: float,
         *,
         comfort_band: float = 0.5,
-        ufh_max_power_w: float | None = None,
+        ufh_nominal_power_w: float | None = None,
         split_power_w: float | None = None,
         dt_minutes: int = 1,
     ) -> SimMetrics:
@@ -138,10 +138,10 @@ class SimMetrics:
             comfort_band: Half-width of the comfort band [degC].
                 A timestep is "comfortable" when
                 ``|T_room - setpoint| <= comfort_band``.
-            ufh_max_power_w: Maximum UFH power [W].  Required (together
+            ufh_nominal_power_w: Maximum UFH power [W].  Required (together
                 with ``split_power_w``) to compute energy metrics.
             split_power_w: Maximum split power [W].  Required (together
-                with ``ufh_max_power_w``) to compute energy metrics.
+                with ``ufh_nominal_power_w``) to compute energy metrics.
             dt_minutes: Simulation timestep length [minutes].
 
         Returns:
@@ -151,7 +151,7 @@ class SimMetrics:
 
         # -- Empty log --------------------------------------------------------
         if n == 0:
-            has_energy = ufh_max_power_w is not None and split_power_w is not None
+            has_energy = ufh_nominal_power_w is not None and split_power_w is not None
             return cls(
                 comfort_pct=0.0,
                 max_overshoot=0.0,
@@ -184,7 +184,7 @@ class SimMetrics:
         prev_hp_mode = None
 
         # Energy accumulators (only when power params provided)
-        compute_energy = ufh_max_power_w is not None and split_power_w is not None
+        compute_energy = ufh_nominal_power_w is not None and split_power_w is not None
         total_floor_energy_j = 0.0
         total_split_energy_j = 0.0
         peak_power = 0.0
@@ -228,9 +228,9 @@ class SimMetrics:
 
             # Energy
             if compute_energy:
-                assert ufh_max_power_w is not None
+                assert ufh_nominal_power_w is not None
                 assert split_power_w is not None
-                floor_power = (rec.valve_position / 100.0) * ufh_max_power_w
+                floor_power = (rec.valve_position / 100.0) * ufh_nominal_power_w
                 split_power = split_power_w if rec.split_mode != SplitMode.OFF else 0.0
                 total_power = floor_power + split_power
 
@@ -488,7 +488,7 @@ def assert_energy_vs_baseline(
     *,
     max_increase: float = 0.1,
     setpoint: float,
-    ufh_max_power_w: float,
+    ufh_nominal_power_w: float,
     split_power_w: float,
     dt_minutes: int = 1,
 ) -> None:
@@ -503,7 +503,7 @@ def assert_energy_vs_baseline(
         baseline_log: Baseline simulation log for comparison.
         max_increase: Maximum allowed fractional increase (e.g. 0.1 = 10%).
         setpoint: Target room temperature [degC] (passed to ``from_log``).
-        ufh_max_power_w: Maximum UFH power [W].
+        ufh_nominal_power_w: Maximum UFH power [W].
         split_power_w: Maximum split power [W].
         dt_minutes: Simulation timestep length [minutes].
 
@@ -515,14 +515,14 @@ def assert_energy_vs_baseline(
     test_metrics = SimMetrics.from_log(
         log,
         setpoint=setpoint,
-        ufh_max_power_w=ufh_max_power_w,
+        ufh_nominal_power_w=ufh_nominal_power_w,
         split_power_w=split_power_w,
         dt_minutes=dt_minutes,
     )
     baseline_metrics = SimMetrics.from_log(
         baseline_log,
         setpoint=setpoint,
-        ufh_max_power_w=ufh_max_power_w,
+        ufh_nominal_power_w=ufh_nominal_power_w,
         split_power_w=split_power_w,
         dt_minutes=dt_minutes,
     )

--- a/pumpahead/scenarios.py
+++ b/pumpahead/scenarios.py
@@ -113,9 +113,11 @@ def _modern_bungalow_single_room() -> BuildingParams:
         windows=salon.windows,
         has_split=False,
         split_power_w=0.0,
-        ufh_max_power_w=salon.ufh_max_power_w,
-        ufh_cooling_max_power_w=salon.ufh_cooling_max_power_w,
         ufh_loops=salon.ufh_loops,
+        pipe_length_m=salon.pipe_length_m,
+        pipe_spacing_m=salon.pipe_spacing_m,
+        pipe_diameter_outer_mm=salon.pipe_diameter_outer_mm,
+        pipe_wall_thickness_mm=salon.pipe_wall_thickness_mm,
         q_int_w=salon.q_int_w,
     )
     return BuildingParams(
@@ -809,8 +811,8 @@ def bathroom_heater_cooling() -> SimScenario:
     override setpoint (below the 25 °C house-wide target) so an
     unconstrained coordinator would try to cool it — but the heater
     has no cooling capability, so the controller must force
-    ``SplitMode.OFF`` and UFH cooling is disabled
-    (``ufh_cooling_max_power_w=0.0``).  Tests:
+    ``SplitMode.OFF`` (enforced via ``auxiliary_type="heater"``).
+    Tests:
 
     * ``split_mode`` is ``OFF`` at every step for ``lazienka``.
     * ``assert_no_opposing_action`` passes (heater never cools).

--- a/pumpahead/simulated_room.py
+++ b/pumpahead/simulated_room.py
@@ -35,18 +35,23 @@ class SimulatedRoom:
     Typical usage::
 
         model = RCModel(params, ModelOrder.THREE, dt=60.0)
-        room = SimulatedRoom("living_room", model, ufh_max_power_w=5000.0)
-        room.apply_actions(valve_position=50.0)
-        room.step(weather_point, q_sol_w=0.0)
-        print(room.T_air)
+        geom = LoopGeometry(
+            effective_pipe_length_m=130.0,
+            pipe_spacing_m=0.15,
+            pipe_diameter_outer_mm=16.0,
+            pipe_wall_thickness_mm=2.0,
+            area_m2=20.0,
+        )
+        room = SimulatedRoom("living_room", model, loop_geometry=geom)
+        sim = BuildingSimulator(room, weather_source)
+        sim.step(Actions(valve_position=50.0))
+        print(sim.room.T_air)
     """
 
     def __init__(
         self,
         name: str,
         model: RCModel,
-        ufh_max_power_w: float = 5000.0,
-        ufh_cooling_max_power_w: float = 0.0,
         split_power_w: float = 0.0,
         q_int_w: float = 0.0,
         loop_geometry: LoopGeometry | None = None,
@@ -56,24 +61,18 @@ class SimulatedRoom:
         Args:
             name: Human-readable room name (e.g. "living_room").
             model: The RC thermal model for this room.
-            ufh_max_power_w: Maximum UFH heat output at 100 % valve [W].
-            ufh_cooling_max_power_w: Maximum UFH cooling power [W].
-                Typically ~60 % of heating power due to asymmetric
-                floor heat transfer.  Zero if no floor cooling.
             split_power_w: Maximum split/AC power [W].  Zero if no split.
             q_int_w: Constant internal heat gains [W] (occupancy, appliances).
-            loop_geometry: Optional ``LoopGeometry`` describing the UFH
-                loop's pipe and floor area.  When provided, the
-                ``BuildingSimulator`` uses the physical EN 1264 model
-                (``pumpahead.ufh_loop.loop_power``) to compute per-room
-                floor power.  When ``None`` (default), the legacy
-                ``valve * ufh_max_power_w`` shim is used — this shim
-                will be removed by issue #144.
+            loop_geometry: ``LoopGeometry`` describing the UFH loop's pipe
+                and floor area.  Required when the room is driven through
+                a ``BuildingSimulator`` — the physical EN 1264 model
+                (``pumpahead.ufh_loop.loop_power``) computes per-room
+                floor power from it.  ``None`` is accepted here for
+                construction flexibility, but ``BuildingSimulator``
+                refuses to run with rooms that lack geometry (issue #144).
         """
         self._name = name
         self._model = model
-        self._ufh_max_power_w = ufh_max_power_w
-        self._ufh_cooling_max_power_w = ufh_cooling_max_power_w
         self._split_power_w = split_power_w
         self._q_int_w = q_int_w
         self._loop_geometry = loop_geometry
@@ -118,16 +117,6 @@ class SimulatedRoom:
         return self._model.params.has_split
 
     @property
-    def ufh_max_power_w(self) -> float:
-        """Return the maximum UFH heat output at 100 % valve [W]."""
-        return self._ufh_max_power_w
-
-    @property
-    def ufh_cooling_max_power_w(self) -> float:
-        """Return the maximum UFH cooling power at 100 % valve [W]."""
-        return self._ufh_cooling_max_power_w
-
-    @property
     def loop_geometry(self) -> LoopGeometry | None:
         """Return the UFH loop geometry, or ``None`` if not configured."""
         return self._loop_geometry
@@ -164,19 +153,6 @@ class SimulatedRoom:
 
     # -- Physics step --------------------------------------------------------
 
-    def step(self, weather: WeatherPoint, q_sol_w: float = 0.0) -> None:
-        """Propagate the thermal state by one time step.
-
-        Converts actuator state to control inputs and delegates to
-        :meth:`step_with_power`.
-
-        Args:
-            weather: Weather conditions at the current time step.
-            q_sol_w: Solar heat gain reaching the room [W].
-        """
-        q_floor = self._valve_position / 100.0 * self._ufh_max_power_w
-        self.step_with_power(weather, q_floor_w=q_floor, q_sol_w=q_sol_w)
-
     def step_with_power(
         self,
         weather: WeatherPoint,
@@ -187,7 +163,7 @@ class SimulatedRoom:
 
         This method is used by multi-room simulation where the HP power
         distribution logic computes ``q_floor_w`` externally instead of
-        deriving it from ``valve_position * ufh_max_power_w``.
+        deriving it from a rated-power proxy.
 
         The split power (``q_conv``) is still read from the internal
         actuator state set by :meth:`apply_actions`.

--- a/pumpahead/simulator.py
+++ b/pumpahead/simulator.py
@@ -135,7 +135,14 @@ class BuildingSimulator:
 
     Typical single-room usage::
 
-        room = SimulatedRoom("living", model, ufh_max_power_w=5000.0)
+        geom = LoopGeometry(
+            effective_pipe_length_m=130.0,
+            pipe_spacing_m=0.15,
+            pipe_diameter_outer_mm=16.0,
+            pipe_wall_thickness_mm=2.0,
+            area_m2=20.0,
+        )
+        room = SimulatedRoom("living", model, loop_geometry=geom)
         weather = SyntheticWeather.constant(T_out=-5.0, GHI=0.0)
         sim = BuildingSimulator(room, weather)
 
@@ -203,6 +210,17 @@ class BuildingSimulator:
             self._rooms: list[SimulatedRoom] = room
         else:
             self._rooms = [room]
+
+        # Issue #144: every room must carry pipe geometry so the
+        # physical UFH model (``pumpahead.ufh_loop.loop_power``) can be
+        # evaluated.  Fail fast instead of silently dropping power.
+        for r in self._rooms:
+            if r.loop_geometry is None:
+                msg = (
+                    f"SimulatedRoom '{r.name}' must have loop_geometry set "
+                    f"(issue #144 removed the proportional-power fallback)"
+                )
+                raise ValueError(msg)
 
         self._weather = weather
         self._hp_mode = hp_mode
@@ -368,55 +386,24 @@ class BuildingSimulator:
     def step(self, actions: Actions) -> Measurements:
         """Apply actions to the first room, propagate, and return measurements.
 
-        This is the original single-room API, fully backward compatible.
-
-        The method follows the ZOH convention:
-        1. Check CWU schedule -- override valve_position to 0 if active.
-        2. Convert ``actions`` to actuator commands.
-        3. Apply actuator commands to the room.
-        4. Query weather at the current time.
-        5. Propagate the RC model by one step.
-        6. Advance the simulation clock.
-        7. Return updated measurements (with optional sensor noise).
+        This is the original single-room API, fully backward compatible
+        from the caller's perspective.  Internally it delegates to
+        :meth:`step_all` so the single-room and multi-room paths share
+        the exact same physical distributor (``_distribute_hp_power`` →
+        ``loop_power``).  Issue #144 eliminated the old proportional
+        ``valve * rated-power`` shim that the legacy single-room
+        ``step()`` used to take.
 
         Args:
             actions: Controller commands for this time step.
 
         Returns:
-            A ``Measurements`` snapshot after the step.
+            A ``Measurements`` snapshot after the step for the first
+            (or only) room.
         """
         first = self._rooms[0]
-
-        # CWU interrupt: force valve closed when HP is in DHW mode
-        effective_valve = actions.valve_position
-        if self._check_cwu_active():
-            effective_valve = 0.0
-
-        # Convert split mode to power
-        if actions.split_mode == SplitMode.OFF:
-            split_power = 0.0
-        elif actions.split_mode == SplitMode.HEATING:
-            split_power = self._split_power_w
-        else:
-            # COOLING: negative power
-            split_power = -self._split_power_w
-
-        # Apply actions to room actuators
-        first.apply_actions(
-            valve_position=effective_valve,
-            split_power_w=split_power,
-        )
-
-        # Get weather at current time
-        wp = self._weather.get(float(self._time_minutes))
-
-        # Propagate physics
-        first.step(wp, q_sol_w=0.0)
-
-        # Advance clock
-        self._time_minutes += self._dt_minutes
-
-        return self.get_measurements()
+        all_meas = self.step_all({first.name: actions})
+        return all_meas[first.name]
 
     # -- Public interface — multi-room ---------------------------------------
 
@@ -557,18 +544,13 @@ class BuildingSimulator:
            ``CoolingCompCurve`` in cooling — falling back to
            ``_FALLBACK_T_SUPPLY_HEATING_C`` / ``_FALLBACK_T_SUPPLY_COOLING_C``
            when no curve is configured.
-        3. For each room:
-
-           * If the room has a ``loop_geometry`` the *physical* UFH
-             model is used: ``Q_max = loop_power(T_supply, T_slab,
-             geometry, mode)`` — this already carries the mode-correct
-             sign (positive in heating, negative in cooling) and
-             returns ``0.0`` when the gradient is wrong (Axiom #3).
-           * Otherwise a backward-compat shim is applied:
-             ``Q_max = ufh_max_power_w`` in heating or
-             ``-ufh_cooling_max_power_w`` in cooling.  Issue #144
-             removes the shim once every building profile has pipe
-             geometry.
+        3. For each room the *physical* UFH model is used:
+           ``Q_max = loop_power(T_supply, T_slab, geometry, mode)``.
+           This already carries the mode-correct sign (positive in
+           heating, negative in cooling) and returns ``0.0`` when the
+           gradient is wrong (Axiom #3).  Every room is required to
+           carry pipe geometry — ``BuildingSimulator.__init__`` raises
+           ``ValueError`` if any room has ``loop_geometry is None``.
 
            Per-room demand is ``valve_fraction * Q_max``.
         4. The absolute total demand is compared against
@@ -600,19 +582,14 @@ class BuildingSimulator:
         )
 
         # Per-room demand (signed: positive heating, negative cooling).
+        # ``BuildingSimulator.__init__`` already guarantees every room
+        # carries loop geometry, so ``r.loop_geometry`` is never ``None``.
         demands: dict[str, float] = {}
         for r in self._rooms:
             valve_frac = max(0.0, min(100.0, actions[r.name].valve_position)) / 100.0
             geometry = r.loop_geometry
-            if geometry is not None:
-                q_max = loop_power(t_supply, r.T_slab, geometry, mode_str)
-            elif mode_str == "heating":
-                q_max = r.ufh_max_power_w
-            else:
-                # Cooling shim: ``ufh_cooling_max_power_w`` is stored as
-                # a non-negative value — negate it to match the signed
-                # convention used by ``loop_power`` in cooling.
-                q_max = -r.ufh_cooling_max_power_w
+            assert geometry is not None  # enforced in __init__
+            q_max = loop_power(t_supply, r.T_slab, geometry, mode_str)
             demands[r.name] = valve_frac * q_max
 
         total_abs = sum(abs(d) for d in demands.values())

--- a/pumpahead/visualization.py
+++ b/pumpahead/visualization.py
@@ -386,7 +386,7 @@ def plot_weather(
 def plot_energy(
     log: SimulationLog,
     *,
-    ufh_max_power_w: float,
+    ufh_nominal_power_w: float,
     split_power_w: float = 0.0,
     dt_minutes: int = 1,
     save_path: Path | None = None,
@@ -396,7 +396,7 @@ def plot_energy(
 
     Args:
         log: Simulation log.
-        ufh_max_power_w: Maximum UFH power [W].
+        ufh_nominal_power_w: Maximum UFH power [W].
         split_power_w: Maximum split power [W].
         dt_minutes: Simulation timestep [minutes].
         save_path: If provided, save the figure as PNG at this path.
@@ -423,7 +423,7 @@ def plot_energy(
     split_acc = 0.0
 
     for rec in records:
-        ufh_power = (rec.valve_position / 100.0) * ufh_max_power_w
+        ufh_power = (rec.valve_position / 100.0) * ufh_nominal_power_w
         split_power = split_power_w if rec.split_mode != SplitMode.OFF else 0.0
         # Convert W * hours to kWh
         ufh_acc += ufh_power * dt_hours / 1000.0
@@ -470,7 +470,7 @@ def plot_dashboard(
     *,
     setpoint: float,
     comfort_band: float = 0.5,
-    ufh_max_power_w: float | None = None,
+    ufh_nominal_power_w: float | None = None,
     split_power_w: float | None = None,
     dt_minutes: int = 1,
     save_path: Path | None = None,
@@ -485,7 +485,7 @@ def plot_dashboard(
         log: Simulation log (may contain multiple rooms).
         setpoint: Target room temperature [degC].
         comfort_band: Half-width of the comfort band [degC].
-        ufh_max_power_w: Maximum UFH power [W] (for metrics).
+        ufh_nominal_power_w: Maximum UFH power [W] (for metrics).
         split_power_w: Maximum split power [W] (for metrics).
         dt_minutes: Simulation timestep [minutes].
         save_path: If provided, save the figure as PNG at this path.
@@ -562,7 +562,7 @@ def plot_dashboard(
             room_log,
             setpoint=setpoint,
             comfort_band=comfort_band,
-            ufh_max_power_w=ufh_max_power_w,
+            ufh_nominal_power_w=ufh_nominal_power_w,
             split_power_w=split_power_w,
             dt_minutes=dt_minutes,
         )
@@ -605,7 +605,7 @@ def generate_plots(
     scenario_name: str = "sim",
     setpoint: float = 21.0,
     comfort_band: float = 0.5,
-    ufh_max_power_w: float | None = None,
+    ufh_nominal_power_w: float | None = None,
     split_power_w: float | None = None,
     dt_minutes: int = 1,
     max_points: int = 5000,
@@ -625,7 +625,7 @@ def generate_plots(
         scenario_name: Prefix for filenames.
         setpoint: Target room temperature [degC].
         comfort_band: Half-width of the comfort band [degC].
-        ufh_max_power_w: Maximum UFH power [W].  When ``None``, the energy
+        ufh_nominal_power_w: Maximum UFH power [W].  When ``None``, the energy
             plot is skipped.
         split_power_w: Maximum split power [W].  When ``None``, the energy
             plot is skipped.
@@ -682,11 +682,11 @@ def generate_plots(
     saved.append(path)
 
     # -- Energy (only when power parameters provided) -------------------------
-    if ufh_max_power_w is not None and split_power_w is not None:
+    if ufh_nominal_power_w is not None and split_power_w is not None:
         path = output_dir / f"{scenario_name}_energy.png"
         fig = plot_energy(
             log,
-            ufh_max_power_w=ufh_max_power_w,
+            ufh_nominal_power_w=ufh_nominal_power_w,
             split_power_w=split_power_w,
             dt_minutes=dt_minutes,
             save_path=path,
@@ -701,7 +701,7 @@ def generate_plots(
         log,
         setpoint=setpoint,
         comfort_band=comfort_band,
-        ufh_max_power_w=ufh_max_power_w,
+        ufh_nominal_power_w=ufh_nominal_power_w,
         split_power_w=split_power_w,
         dt_minutes=dt_minutes,
         save_path=path,

--- a/tests/simulation/conftest.py
+++ b/tests/simulation/conftest.py
@@ -81,16 +81,12 @@ def _build_simulator(scenario: SimScenario) -> BuildingSimulator:
     rooms: list[SimulatedRoom] = []
     for room_cfg in scenario.building.rooms:
         model = RCModel(room_cfg.params, ModelOrder.THREE, dt=scenario.dt_seconds)
-        try:
-            geometry = LoopGeometry.from_room_config(room_cfg)
-        except ValueError:
-            # Room has no pipe geometry — fall back to legacy shim.
-            geometry = None
+        # Post-#144 every RoomConfig carries pipe geometry; propagate
+        # the ValueError if a regression slips through.
+        geometry = LoopGeometry.from_room_config(room_cfg)
         sim_room = SimulatedRoom(
             room_cfg.name,
             model,
-            ufh_max_power_w=room_cfg.ufh_max_power_w,
-            ufh_cooling_max_power_w=room_cfg.ufh_cooling_max_power_w,
             split_power_w=room_cfg.split_power_w,
             q_int_w=room_cfg.q_int_w,
             loop_geometry=geometry,
@@ -220,7 +216,7 @@ def run_scenario() -> Callable[
         metrics = SimMetrics.from_log(
             room_log,
             setpoint=setpoint,
-            ufh_max_power_w=first_room.ufh_max_power_w,
+            ufh_nominal_power_w=first_room.nominal_ufh_power_heating_w,
             split_power_w=first_room.split_power_w,
             dt_minutes=1,
         )

--- a/tests/simulation/test_cooling_safety.py
+++ b/tests/simulation/test_cooling_safety.py
@@ -82,7 +82,7 @@ class TestDewPointStress:
             metrics = SimMetrics.from_log(
                 room_log,
                 setpoint=scenario.controller.setpoint,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
+                ufh_nominal_power_w=room_cfg.nominal_ufh_power_heating_w,
                 split_power_w=room_cfg.split_power_w,
                 dt_minutes=1,
             )
@@ -146,7 +146,7 @@ class TestDewPointStress:
             metrics = SimMetrics.from_log(
                 room_log,
                 setpoint=scenario.controller.setpoint,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
+                ufh_nominal_power_w=room_cfg.nominal_ufh_power_heating_w,
                 split_power_w=room_cfg.split_power_w,
                 dt_minutes=1,
             )
@@ -302,7 +302,7 @@ class TestCoolingSafetyComfort:
                 room_log,
                 setpoint=scenario.controller.setpoint,
                 comfort_band=6.0,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
+                ufh_nominal_power_w=room_cfg.nominal_ufh_power_heating_w,
                 split_power_w=room_cfg.split_power_w,
                 dt_minutes=1,
             )

--- a/tests/simulation/test_pid_scenarios.py
+++ b/tests/simulation/test_pid_scenarios.py
@@ -53,8 +53,8 @@ def _standard_weather_comp() -> WeatherCompCurve:
     """Return a realistic heating weather-compensation curve.
 
     Post-#144 the simulator uses the physical ``ufh_loop.loop_power`` model
-    (EN 1264 reduced formula) instead of the legacy ``valve * ufh_max_power_w``
-    shim.  That model requires realistic supply temperatures — real heat pumps
+    (EN 1264 reduced formula) instead of the legacy rated-power shim.
+    That model requires realistic supply temperatures — real heat pumps
     raise ``T_supply`` at low outdoor temperatures via a weather-compensation
     curve.  The old tests passed a nominal 5 kW rating that was independent
     of ``T_supply``; now we provide a WCC so the physical loop can deliver

--- a/tests/simulation/test_pid_scenarios.py
+++ b/tests/simulation/test_pid_scenarios.py
@@ -35,6 +35,7 @@ from pumpahead.simulation_log import SimulationLog
 from pumpahead.simulator import BuildingSimulator, HeatPumpMode
 from pumpahead.ufh_loop import LoopGeometry
 from pumpahead.weather import ChannelProfile, ProfileKind, SyntheticWeather
+from pumpahead.weather_comp import WeatherCompCurve
 
 
 def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
@@ -45,6 +46,32 @@ def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
         pipe_diameter_outer_mm=16.0,
         pipe_wall_thickness_mm=2.0,
         area_m2=area_m2,
+    )
+
+
+def _standard_weather_comp() -> WeatherCompCurve:
+    """Return a realistic heating weather-compensation curve.
+
+    Post-#144 the simulator uses the physical ``ufh_loop.loop_power`` model
+    (EN 1264 reduced formula) instead of the legacy ``valve * ufh_max_power_w``
+    shim.  That model requires realistic supply temperatures — real heat pumps
+    raise ``T_supply`` at low outdoor temperatures via a weather-compensation
+    curve.  The old tests passed a nominal 5 kW rating that was independent
+    of ``T_supply``; now we provide a WCC so the physical loop can deliver
+    the expected power during the scenarios.
+
+    Curve: ``T_supply(T_out)``:
+        * T_out >=  10 C  => 45 C (base)
+        * T_out =    0 C  => 53 C
+        * T_out =   -5 C  => 55 C (clamped)
+        * T_out = -15 C  => 55 C (clamped)
+    """
+    return WeatherCompCurve(
+        t_supply_base=45.0,
+        slope=0.8,
+        t_neutral=10.0,
+        t_supply_max=55.0,
+        t_supply_min=25.0,
     )
 
 
@@ -117,7 +144,11 @@ class TestPIDSteadyState:
     ) -> None:
         """Steady-state comfort percentage exceeds 95 %."""
         base = SCENARIO_LIBRARY["steady_state"]()
-        scenario = replace(base, controller=_TUNED_CONFIG)
+        scenario = replace(
+            base,
+            controller=_TUNED_CONFIG,
+            weather_comp=_standard_weather_comp(),
+        )
         _log, metrics = run_scenario(scenario, None)
         assert metrics.comfort_pct > 95.0, (
             f"steady_state comfort {metrics.comfort_pct:.1f}% <= 95%"
@@ -131,7 +162,11 @@ class TestPIDSteadyState:
     ) -> None:
         """Steady-state overshoot is less than 1.0 degC."""
         base = SCENARIO_LIBRARY["steady_state"]()
-        scenario = replace(base, controller=_TUNED_CONFIG)
+        scenario = replace(
+            base,
+            controller=_TUNED_CONFIG,
+            weather_comp=_standard_weather_comp(),
+        )
         _log, metrics = run_scenario(scenario, None)
         assert metrics.max_overshoot < 1.0, (
             f"steady_state overshoot {metrics.max_overshoot:.2f} >= 1.0 degC"
@@ -145,7 +180,11 @@ class TestPIDSteadyState:
     ) -> None:
         """Floor temperature stays within safe limits during steady state."""
         base = SCENARIO_LIBRARY["steady_state"]()
-        scenario = replace(base, controller=_TUNED_CONFIG)
+        scenario = replace(
+            base,
+            controller=_TUNED_CONFIG,
+            weather_comp=_standard_weather_comp(),
+        )
         log, _metrics = run_scenario(scenario, None)
         first_room = scenario.building.rooms[0].name
         assert_floor_temp_safe(log.get_room(first_room))
@@ -195,6 +234,7 @@ class TestPIDColdSnap:
             duration_minutes=4320,
             mode="heating",
             dt_seconds=60.0,
+            weather_comp=_standard_weather_comp(),
             description=(
                 "Single-room cold snap (well insulated): step from 0C "
                 "to -15C at t=1440. Tests PID response to sudden "
@@ -393,6 +433,7 @@ class TestPIDMultiRoom:
             weather,
             hp_mode=HeatPumpMode.HEATING,
             hp_max_power_w=40000.0,
+            weather_comp=_standard_weather_comp(),
         )
 
         config = ControllerConfig(

--- a/tests/simulation/test_pid_scenarios.py
+++ b/tests/simulation/test_pid_scenarios.py
@@ -33,7 +33,20 @@ from pumpahead.scenarios import SCENARIO_LIBRARY
 from pumpahead.simulated_room import SimulatedRoom
 from pumpahead.simulation_log import SimulationLog
 from pumpahead.simulator import BuildingSimulator, HeatPumpMode
+from pumpahead.ufh_loop import LoopGeometry
 from pumpahead.weather import ChannelProfile, ProfileKind, SyntheticWeather
+
+
+def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
+    """Return a standard UFH loop geometry used throughout the tests."""
+    return LoopGeometry(
+        effective_pipe_length_m=130.0,
+        pipe_spacing_m=0.15,
+        pipe_diameter_outer_mm=16.0,
+        pipe_wall_thickness_mm=2.0,
+        area_m2=area_m2,
+    )
+
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -66,9 +79,7 @@ _TUNED_CONFIG = ControllerConfig(
 """Tuned PID gains validated via gain sweep during implementation."""
 
 
-def _make_single_room_building(
-    ufh_max_power_w: float = 5000.0,
-) -> BuildingParams:
+def _make_single_room_building() -> BuildingParams:
     """Create a single-room building with SISO parameters."""
     room = RoomConfig(
         name="test_room",
@@ -76,7 +87,7 @@ def _make_single_room_building(
         params=_SISO_PARAMS,
         has_split=False,
         split_power_w=0.0,
-        ufh_max_power_w=ufh_max_power_w,
+        pipe_spacing_m=0.20,
     )
     return BuildingParams(
         rooms=(room,),
@@ -269,7 +280,7 @@ class TestPIDAntiWindup:
         )
 
         model = RCModel(_SISO_PARAMS, ModelOrder.THREE, dt=60.0)
-        room = SimulatedRoom("test_room", model, ufh_max_power_w=5000.0)
+        room = SimulatedRoom("test_room", model, loop_geometry=_standard_geometry())
         sim = BuildingSimulator([room], weather, hp_mode=HeatPumpMode.HEATING)
 
         config = ControllerConfig(
@@ -319,7 +330,7 @@ class TestPIDValveFloor:
         )
 
         model = RCModel(_SISO_PARAMS, ModelOrder.THREE, dt=60.0)
-        room = SimulatedRoom("test_room", model, ufh_max_power_w=5000.0)
+        room = SimulatedRoom("test_room", model, loop_geometry=_standard_geometry())
         sim = BuildingSimulator([room], weather, hp_mode=HeatPumpMode.HEATING)
 
         valve_floor = 12.0
@@ -373,7 +384,9 @@ class TestPIDMultiRoom:
         rooms: list[SimulatedRoom] = []
         for i in range(8):
             model = RCModel(_SISO_PARAMS, ModelOrder.THREE, dt=60.0)
-            rooms.append(SimulatedRoom(f"room_{i}", model, ufh_max_power_w=5000.0))
+            rooms.append(
+                SimulatedRoom(f"room_{i}", model, loop_geometry=_standard_geometry())
+            )
 
         sim = BuildingSimulator(
             rooms,

--- a/tests/simulation/test_split_scenarios.py
+++ b/tests/simulation/test_split_scenarios.py
@@ -81,7 +81,7 @@ class TestDualSourceSteadyState:
             metrics = SimMetrics.from_log(
                 room_log,
                 setpoint=scenario.controller.setpoint,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
+                ufh_nominal_power_w=room_cfg.nominal_ufh_power_heating_w,
                 split_power_w=room_cfg.split_power_w,
             )
             assert metrics.split_runtime_pct < 50.0, (
@@ -115,7 +115,7 @@ class TestDualSourceSteadyState:
                 room_log,
                 setpoint=scenario.controller.setpoint,
                 comfort_band=2.0,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
+                ufh_nominal_power_w=room_cfg.nominal_ufh_power_heating_w,
                 split_power_w=room_cfg.split_power_w,
             )
             assert metrics.comfort_pct > 80.0, (
@@ -154,7 +154,7 @@ class TestDualSourceSteadyState:
             metrics = SimMetrics.from_log(
                 room_log,
                 setpoint=scenario.controller.setpoint,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
+                ufh_nominal_power_w=room_cfg.nominal_ufh_power_heating_w,
                 split_power_w=room_cfg.split_power_w,
             )
             assert metrics.split_runtime_pct == pytest.approx(0.0), (
@@ -270,7 +270,7 @@ class TestPriorityInversionStress:
             metrics = SimMetrics.from_log(
                 room_log,
                 setpoint=scenario.controller.setpoint,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
+                ufh_nominal_power_w=room_cfg.nominal_ufh_power_heating_w,
                 split_power_w=room_cfg.split_power_w,
             )
             assert metrics.split_runtime_pct < 50.0, (
@@ -326,7 +326,7 @@ class TestBathroomHeater:
             room_log,
             setpoint=24.0,
             comfort_band=0.7,
-            ufh_max_power_w=room_cfg.ufh_max_power_w,
+            ufh_nominal_power_w=room_cfg.nominal_ufh_power_heating_w,
             split_power_w=room_cfg.split_power_w,
         )
         assert metrics.comfort_pct > 80.0, (
@@ -354,7 +354,7 @@ class TestBathroomHeater:
                 room_log,
                 setpoint=20.0,
                 comfort_band=1.0,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
+                ufh_nominal_power_w=room_cfg.nominal_ufh_power_heating_w,
                 split_power_w=room_cfg.split_power_w,
             )
             assert metrics.comfort_pct > 80.0, (
@@ -377,7 +377,7 @@ class TestBathroomHeater:
         metrics = SimMetrics.from_log(
             room_log,
             setpoint=24.0,
-            ufh_max_power_w=room_cfg.ufh_max_power_w,
+            ufh_nominal_power_w=room_cfg.nominal_ufh_power_heating_w,
             split_power_w=room_cfg.split_power_w,
         )
         assert metrics.split_runtime_pct > 0.0, (

--- a/tests/unit/test_assertions.py
+++ b/tests/unit/test_assertions.py
@@ -529,7 +529,7 @@ class TestAssertEnergyVsBaseline:
             baseline_log,
             max_increase=max_increase,
             setpoint=self._SETPOINT,
-            ufh_max_power_w=self._UFH_MAX_POWER_W,
+            ufh_nominal_power_w=self._UFH_MAX_POWER_W,
             split_power_w=self._SPLIT_POWER_W,
             dt_minutes=self._DT_MINUTES,
         )

--- a/tests/unit/test_building_profiles.py
+++ b/tests/unit/test_building_profiles.py
@@ -308,12 +308,13 @@ class TestPhysicalSensibility:
         assert salon.params.C_air > garderoba.params.C_air
 
     def test_ufh_max_power_reasonable(self) -> None:
-        """UFH max power is in a reasonable range (300-10000 W)."""
+        """Nominal UFH heating power is in a reasonable range (300-10000 W)."""
         for name, factory in BUILDING_PROFILES.items():
             building = factory()
             for room in building.rooms:
-                assert 300 <= room.ufh_max_power_w <= 10_000, (
-                    f"{name}/{room.name}: ufh_max_power_w={room.ufh_max_power_w}"
+                nominal = room.nominal_ufh_power_heating_w
+                assert 300 <= nominal <= 10_000, (
+                    f"{name}/{room.name}: nominal_ufh_power_heating_w={nominal}"
                 )
 
     def test_heavy_construction_higher_c_wall(self) -> None:

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -68,6 +68,9 @@ def _make_room(
     """Create a valid RoomConfig with sensible defaults."""
     if params is None:
         params = _siso_params()
+    # Every RoomConfig needs pipe geometry post-#144 so the nominal-power
+    # properties (and ``LoopGeometry.from_room_config``) resolve.
+    kwargs.setdefault("pipe_spacing_m", 0.20)
     return RoomConfig(name=name, area_m2=area_m2, params=params, **kwargs)  # type: ignore[arg-type]
 
 
@@ -103,7 +106,9 @@ class TestRoomConfig:
         assert room.area_m2 == 25.0
         assert room.has_split is False
         assert room.split_power_w == 0.0
-        assert room.ufh_max_power_w == 5000.0
+        # Nominal power derived from the default pipe geometry (must be
+        # positive — the exact value depends on EN 1264 physics).
+        assert room.nominal_ufh_power_heating_w > 0
         assert room.ufh_loops == 1
         assert room.q_int_w == 0.0
         assert room.windows == ()
@@ -170,16 +175,6 @@ class TestRoomConfig:
                 has_split=False,
                 split_power_w=1000.0,
             )
-
-    def test_ufh_max_power_zero_raises(self) -> None:
-        """Zero UFH power raises ValueError."""
-        with pytest.raises(ValueError, match="ufh_max_power_w must be > 0"):
-            _make_room(ufh_max_power_w=0.0)
-
-    def test_ufh_max_power_negative_raises(self) -> None:
-        """Negative UFH power raises ValueError."""
-        with pytest.raises(ValueError, match="ufh_max_power_w must be > 0"):
-            _make_room(ufh_max_power_w=-500.0)
 
     def test_ufh_loops_zero_raises(self) -> None:
         """Zero UFH loops raises ValueError."""
@@ -251,19 +246,18 @@ class TestRoomConfig:
         assert room.auxiliary_type == "split"
 
     def test_auxiliary_type_heater_valid(self) -> None:
-        """``"heater"`` is accepted when has_split=True and cooling=0.0."""
+        """``"heater"`` is accepted when has_split=True."""
         room = RoomConfig(
             name="lazienka",
             area_m2=9.0,
             params=_mimo_params(),
             has_split=True,
             split_power_w=300.0,
-            ufh_cooling_max_power_w=0.0,
+            pipe_spacing_m=0.20,
             auxiliary_type="heater",
         )
         assert room.auxiliary_type == "heater"
         assert room.has_split is True
-        assert room.ufh_cooling_max_power_w == 0.0
 
     def test_auxiliary_type_invalid_value_raises(self) -> None:
         """Unknown auxiliary_type string raises ValueError."""
@@ -283,19 +277,6 @@ class TestRoomConfig:
                 area_m2=20.0,
                 params=_siso_params(),
                 has_split=False,
-                auxiliary_type="heater",
-            )
-
-    def test_auxiliary_type_heater_with_cooling_raises(self) -> None:
-        """``"heater"`` with nonzero cooling power raises ValueError."""
-        with pytest.raises(ValueError, match="requires ufh_cooling_max_power_w=0.0"):
-            RoomConfig(
-                name="bad_room",
-                area_m2=20.0,
-                params=_mimo_params(),
-                has_split=True,
-                split_power_w=300.0,
-                ufh_cooling_max_power_w=1000.0,
                 auxiliary_type="heater",
             )
 

--- a/tests/unit/test_cooling_mode.py
+++ b/tests/unit/test_cooling_mode.py
@@ -15,7 +15,7 @@ import numpy as np
 import pytest
 
 from pumpahead.building_profiles import modern_bungalow
-from pumpahead.config import ControllerConfig, RoomConfig
+from pumpahead.config import ControllerConfig
 from pumpahead.controller import PumpAheadController
 from pumpahead.mode_controller import ModeController
 from pumpahead.model import ModelOrder, RCModel, RCParams
@@ -32,7 +32,20 @@ from pumpahead.simulator import (
     Measurements,
     SplitMode,
 )
+from pumpahead.ufh_loop import LoopGeometry
 from pumpahead.weather import SyntheticWeather
+
+
+def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
+    """Return a standard UFH loop geometry used throughout the tests."""
+    return LoopGeometry(
+        effective_pipe_length_m=130.0,
+        pipe_spacing_m=0.15,
+        pipe_diameter_outer_mm=16.0,
+        pipe_wall_thickness_mm=2.0,
+        area_m2=area_m2,
+    )
+
 
 # ---------------------------------------------------------------------------
 # TestRCModelCooling — RC model correctly propagates negative Q_floor
@@ -234,106 +247,50 @@ class TestModeController:
 
 @pytest.mark.unit
 class TestCoolingPowerAsymmetry:
-    """Tests for ufh_cooling_max_power_w in RoomConfig."""
+    """Tests for the ``nominal_ufh_power_*`` computed properties.
 
-    def test_default_cooling_power_is_zero(self) -> None:
-        """Default ufh_cooling_max_power_w is 0.0."""
-        params = RCParams(
-            C_air=60_000,
-            C_slab=3_250_000,
-            C_wall=1_500_000,
-            R_sf=0.01,
-            R_wi=0.02,
-            R_wo=0.03,
-            R_ve=0.03,
-            R_ins=0.01,
-            f_conv=0.6,
-            f_rad=0.4,
-            T_ground=10.0,
-            has_split=False,
-        )
-        room = RoomConfig(
-            name="test",
-            area_m2=20.0,
-            params=params,
-            ufh_max_power_w=5000.0,
-        )
-        assert room.ufh_cooling_max_power_w == 0.0
-
-    def test_explicit_cooling_power(self) -> None:
-        """Explicit ufh_cooling_max_power_w is stored correctly."""
-        params = RCParams(
-            C_air=60_000,
-            C_slab=3_250_000,
-            C_wall=1_500_000,
-            R_sf=0.01,
-            R_wi=0.02,
-            R_wo=0.03,
-            R_ve=0.03,
-            R_ins=0.01,
-            f_conv=0.6,
-            f_rad=0.4,
-            T_ground=10.0,
-            has_split=False,
-        )
-        room = RoomConfig(
-            name="test",
-            area_m2=20.0,
-            params=params,
-            ufh_max_power_w=5000.0,
-            ufh_cooling_max_power_w=3000.0,
-        )
-        assert room.ufh_cooling_max_power_w == 3000.0
-
-    def test_negative_cooling_power_raises(self) -> None:
-        """Negative ufh_cooling_max_power_w raises ValueError."""
-        params = RCParams(
-            C_air=60_000,
-            C_slab=3_250_000,
-            C_wall=1_500_000,
-            R_sf=0.01,
-            R_wi=0.02,
-            R_wo=0.03,
-            R_ve=0.03,
-            R_ins=0.01,
-            f_conv=0.6,
-            f_rad=0.4,
-            T_ground=10.0,
-            has_split=False,
-        )
-        with pytest.raises(ValueError, match="ufh_cooling_max_power_w"):
-            RoomConfig(
-                name="test",
-                area_m2=20.0,
-                params=params,
-                ufh_max_power_w=5000.0,
-                ufh_cooling_max_power_w=-100.0,
-            )
+    Post-#144 the hand-picked rated power fields are gone — equivalent
+    values are computed from pipe geometry + EN 1264 via the
+    ``nominal_ufh_power_heating_w`` and ``nominal_ufh_power_cooling_w``
+    properties.
+    """
 
     def test_modern_bungalow_rooms_have_cooling_power(self) -> None:
-        """All modern_bungalow rooms have ufh_cooling_max_power_w > 0."""
+        """All modern_bungalow rooms have nominal_ufh_power_cooling_w > 0."""
         building = modern_bungalow()
         for room in building.rooms:
-            assert room.ufh_cooling_max_power_w > 0, (
-                f"{room.name}: ufh_cooling_max_power_w should be > 0"
+            cooling = room.nominal_ufh_power_cooling_w
+            assert cooling > 0, (
+                f"{room.name}: nominal_ufh_power_cooling_w should be > 0, got {cooling}"
             )
 
     def test_cooling_power_less_than_heating(self) -> None:
         """All modern_bungalow rooms have cooling power < heating power."""
         building = modern_bungalow()
         for room in building.rooms:
-            assert room.ufh_cooling_max_power_w < room.ufh_max_power_w, (
-                f"{room.name}: cooling ({room.ufh_cooling_max_power_w}) "
-                f"must be < heating ({room.ufh_max_power_w})"
+            heating = room.nominal_ufh_power_heating_w
+            cooling = room.nominal_ufh_power_cooling_w
+            assert cooling < heating, (
+                f"{room.name}: cooling ({cooling}) must be < heating ({heating})"
             )
 
     def test_cooling_power_roughly_60_percent_of_heating(self) -> None:
-        """Cooling power is approximately 60% of heating power."""
+        """Cooling power lands in a physically plausible band vs heating.
+
+        The prior hand-picked 0.6 ratio is now derived from EN 1264 with
+        LMTDs using ``DT_HEATING=5`` (heating Δ15 K gradient) and
+        ``DT_COOLING=3`` (cooling Δ7 K gradient).  The exact geometric
+        ratio depends on the chosen T_supply/T_slab anchors (35/20 and
+        18/25) and lands in the [0.4, 0.7] window.
+        """
         building = modern_bungalow()
         for room in building.rooms:
-            ratio = room.ufh_cooling_max_power_w / room.ufh_max_power_w
-            assert 0.5 <= ratio <= 0.7, (
-                f"{room.name}: cooling/heating ratio {ratio:.2f} outside [0.5, 0.7]"
+            heating = room.nominal_ufh_power_heating_w
+            cooling = room.nominal_ufh_power_cooling_w
+            ratio = cooling / heating
+            assert 0.4 <= ratio <= 0.7, (
+                f"{room.name}: cooling/heating ratio {ratio:.2f} outside "
+                f"[0.4, 0.7] (cooling={cooling:.1f}, heating={heating:.1f})"
             )
 
 
@@ -547,8 +504,7 @@ class TestControllerAutoMode:
         sim_room = SimulatedRoom(
             "room",
             room_model,
-            ufh_max_power_w=5000.0,
-            ufh_cooling_max_power_w=3000.0,
+            loop_geometry=_standard_geometry(),
         )
         sim = BuildingSimulator(
             sim_room,
@@ -645,9 +601,11 @@ class TestSimulatorCoolingMode:
         room = SimulatedRoom(
             "test",
             model,
-            ufh_max_power_w=5000.0,
-            ufh_cooling_max_power_w=3000.0,
+            loop_geometry=_standard_geometry(),
         )
+        # Slab warmer than supply+DT_COOLING so loop_power's LMTD is
+        # valid on both ends (T_slab > T_return_estimate = 18+3 = 21).
+        room.set_initial_state(np.array([25.0, 25.0, 25.0]))
         weather = SyntheticWeather.constant(T_out=30.0, GHI=0.0)
         sim = BuildingSimulator(
             room,
@@ -659,7 +617,6 @@ class TestSimulatorCoolingMode:
         allocated = sim._distribute_hp_power(actions)
 
         assert allocated["test"] < 0, "Cooling mode should produce negative power"
-        assert allocated["test"] == pytest.approx(-1500.0)  # 50% of 3000
 
     def test_distribute_hp_power_positive_in_heating(self) -> None:
         """In heating mode, _distribute_hp_power returns positive values."""
@@ -681,8 +638,7 @@ class TestSimulatorCoolingMode:
         room = SimulatedRoom(
             "test",
             model,
-            ufh_max_power_w=5000.0,
-            ufh_cooling_max_power_w=3000.0,
+            loop_geometry=_standard_geometry(),
         )
         weather = SyntheticWeather.constant(T_out=0.0, GHI=0.0)
         sim = BuildingSimulator(
@@ -695,7 +651,6 @@ class TestSimulatorCoolingMode:
         allocated = sim._distribute_hp_power(actions)
 
         assert allocated["test"] > 0, "Heating mode should produce positive power"
-        assert allocated["test"] == pytest.approx(2500.0)  # 50% of 5000
 
     def test_set_hp_mode(self) -> None:
         """set_hp_mode updates the simulator's mode."""
@@ -714,7 +669,7 @@ class TestSimulatorCoolingMode:
             has_split=False,
         )
         model = RCModel(params, ModelOrder.THREE, dt=60.0)
-        room = SimulatedRoom("test", model)
+        room = SimulatedRoom("test", model, loop_geometry=_standard_geometry())
         weather = SyntheticWeather.constant(T_out=0.0, GHI=0.0)
         sim = BuildingSimulator(room, weather, hp_mode=HeatPumpMode.HEATING)
 
@@ -722,8 +677,8 @@ class TestSimulatorCoolingMode:
         sim.set_hp_mode(HeatPumpMode.COOLING)
         assert sim.hp_mode == HeatPumpMode.COOLING
 
-    def test_zero_cooling_power_means_no_floor_cooling(self) -> None:
-        """Room with ufh_cooling_max_power_w=0 produces Q_floor=0 in cooling mode."""
+    def test_axiom3_blocks_cooling_when_slab_below_supply(self) -> None:
+        """Cooling with T_slab <= T_supply produces Q_floor=0 (Axiom #3)."""
         params = RCParams(
             C_air=60_000,
             C_slab=3_250_000,
@@ -742,9 +697,12 @@ class TestSimulatorCoolingMode:
         room = SimulatedRoom(
             "test",
             model,
-            ufh_max_power_w=5000.0,
-            ufh_cooling_max_power_w=0.0,
+            loop_geometry=_standard_geometry(),
         )
+        # Set slab below the fallback cooling supply (18 C) — loop_power
+        # must return 0 because the gradient would drive heat the wrong
+        # way (Axiom #3).
+        room.set_initial_state(np.array([16.0, 15.0, 16.0]))
         weather = SyntheticWeather.constant(T_out=30.0, GHI=0.0)
         sim = BuildingSimulator(
             room,
@@ -778,21 +736,22 @@ class TestSimulatorCoolingMode:
         room1 = SimulatedRoom(
             "a",
             model1,
-            ufh_max_power_w=5000.0,
-            ufh_cooling_max_power_w=3000.0,
+            loop_geometry=_standard_geometry(),
         )
         room2 = SimulatedRoom(
             "b",
             model2,
-            ufh_max_power_w=5000.0,
-            ufh_cooling_max_power_w=3000.0,
+            loop_geometry=_standard_geometry(),
         )
+        # Slab well above supply+DT_COOLING so cooling LMTD is valid.
+        room1.set_initial_state(np.array([25.0, 25.0, 25.0]))
+        room2.set_initial_state(np.array([25.0, 25.0, 25.0]))
         weather = SyntheticWeather.constant(T_out=30.0, GHI=0.0)
         sim = BuildingSimulator(
             [room1, room2],
             weather,
             hp_mode=HeatPumpMode.COOLING,
-            hp_max_power_w=4000.0,  # Limit < total demand
+            hp_max_power_w=1000.0,  # Limit well below total demand to force scaling.
         )
 
         actions = {
@@ -801,11 +760,10 @@ class TestSimulatorCoolingMode:
         }
         allocated = sim._distribute_hp_power(actions)
 
-        # Total demand = 6000, HP limit = 4000, scale = 4000/6000
         assert allocated["a"] < 0
         assert allocated["b"] < 0
         # Total magnitude should not exceed HP capacity
-        assert abs(allocated["a"]) + abs(allocated["b"]) <= 4000.0 + 0.01
+        assert abs(allocated["a"]) + abs(allocated["b"]) <= 1000.0 + 0.01
 
     def test_step_all_cooling_mode_propagates(self) -> None:
         """step_all in cooling mode propagates negative Q_floor through RC model."""
@@ -827,8 +785,7 @@ class TestSimulatorCoolingMode:
         room = SimulatedRoom(
             "test",
             model,
-            ufh_max_power_w=5000.0,
-            ufh_cooling_max_power_w=3000.0,
+            loop_geometry=_standard_geometry(),
         )
         room.set_initial_state(np.array([28.0, 28.0, 28.0]))
         weather = SyntheticWeather.constant(T_out=28.0, GHI=0.0)
@@ -880,11 +837,11 @@ class TestHotJulyScenario:
         rooms: list[SimulatedRoom] = []
         for room_cfg in building.rooms:
             model = RCModel(room_cfg.params, ModelOrder.THREE, dt=60.0)
+            geometry = LoopGeometry.from_room_config(room_cfg)
             sim_room = SimulatedRoom(
                 room_cfg.name,
                 model,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
-                ufh_cooling_max_power_w=room_cfg.ufh_cooling_max_power_w,
+                loop_geometry=geometry,
             )
             rooms.append(sim_room)
 
@@ -921,12 +878,12 @@ class TestHotJulyScenario:
         rooms: list[SimulatedRoom] = []
         for room_cfg in building.rooms:
             model = RCModel(room_cfg.params, ModelOrder.THREE, dt=60.0)
+            geometry = LoopGeometry.from_room_config(room_cfg)
             sim_room = SimulatedRoom(
                 room_cfg.name,
                 model,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
-                ufh_cooling_max_power_w=room_cfg.ufh_cooling_max_power_w,
                 split_power_w=room_cfg.split_power_w,
+                loop_geometry=geometry,
             )
             rooms.append(sim_room)
 

--- a/tests/unit/test_cwu_interrupt.py
+++ b/tests/unit/test_cwu_interrupt.py
@@ -20,6 +20,7 @@ from pumpahead.simulator import (
     BuildingSimulator,
     SplitMode,
 )
+from pumpahead.ufh_loop import LoopGeometry
 from pumpahead.weather import SyntheticWeather
 
 # ---------------------------------------------------------------------------
@@ -27,20 +28,31 @@ from pumpahead.weather import SyntheticWeather
 # ---------------------------------------------------------------------------
 
 
+def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
+    """Return a standard UFH loop geometry used throughout the tests."""
+    return LoopGeometry(
+        effective_pipe_length_m=130.0,
+        pipe_spacing_m=0.15,
+        pipe_diameter_outer_mm=16.0,
+        pipe_wall_thickness_mm=2.0,
+        area_m2=area_m2,
+    )
+
+
 @pytest.fixture()
 def siso_room(model_3r3c: RCModel) -> SimulatedRoom:
-    """SISO simulated room with 5000 W UFH capacity."""
-    return SimulatedRoom("cwu_test", model_3r3c, ufh_max_power_w=5000.0)
+    """SISO simulated room with standard UFH loop geometry."""
+    return SimulatedRoom("cwu_test", model_3r3c, loop_geometry=_standard_geometry())
 
 
 @pytest.fixture()
 def mimo_room(model_3r3c_mimo: RCModel) -> SimulatedRoom:
-    """MIMO simulated room with 5000 W UFH and 2500 W split."""
+    """MIMO simulated room with 2500 W split and standard UFH loop."""
     return SimulatedRoom(
         "cwu_test_mimo",
         model_3r3c_mimo,
-        ufh_max_power_w=5000.0,
         split_power_w=2500.0,
+        loop_geometry=_standard_geometry(),
     )
 
 
@@ -144,7 +156,7 @@ class TestCWUInterruptSimulation:
         # Reference simulator without CWU (valve=0)
         params = siso_room._model.params
         model_ref = RCModel(params, ModelOrder.THREE, dt=60.0)
-        room_ref = SimulatedRoom("ref", model_ref, ufh_max_power_w=5000.0)
+        room_ref = SimulatedRoom("ref", model_ref, loop_geometry=_standard_geometry())
         sim_ref = BuildingSimulator(room_ref, constant_weather)
 
         # Both run with valve=100 command, but CWU sim should behave like valve=0
@@ -224,7 +236,10 @@ class TestCWUInterruptSimulation:
         params_mimo = mimo_room._model.params
         model_ref = RCModel(params_mimo, ModelOrder.THREE, dt=60.0)
         room_ref = SimulatedRoom(
-            "ref_mimo", model_ref, ufh_max_power_w=5000.0, split_power_w=2500.0
+            "ref_mimo",
+            model_ref,
+            split_power_w=2500.0,
+            loop_geometry=_standard_geometry(),
         )
         sim_ref = BuildingSimulator(room_ref, constant_weather)
 

--- a/tests/unit/test_epic02_integration.py
+++ b/tests/unit/test_epic02_integration.py
@@ -31,6 +31,7 @@ from pumpahead.simulator import (
     Measurements,
     SplitMode,
 )
+from pumpahead.ufh_loop import LoopGeometry
 from pumpahead.weather import SyntheticWeather
 
 # ---------------------------------------------------------------------------
@@ -38,28 +39,45 @@ from pumpahead.weather import SyntheticWeather
 # ---------------------------------------------------------------------------
 
 
+def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
+    """Return a standard UFH loop geometry used throughout the tests."""
+    return LoopGeometry(
+        effective_pipe_length_m=130.0,
+        pipe_spacing_m=0.15,
+        pipe_diameter_outer_mm=16.0,
+        pipe_wall_thickness_mm=2.0,
+        area_m2=area_m2,
+    )
+
+
 def _make_room(
     name: str,
     params: RCParams,
-    ufh_max_power_w: float = 5000.0,
+    *,
     split_power_w: float = 0.0,
+    loop_geometry: LoopGeometry | None = None,
 ) -> SimulatedRoom:
     """Create a SimulatedRoom with a 3R3C model at dt=60s."""
     model = RCModel(params, ModelOrder.THREE, dt=60.0)
+    if loop_geometry is None:
+        loop_geometry = _standard_geometry()
     return SimulatedRoom(
-        name, model, ufh_max_power_w=ufh_max_power_w, split_power_w=split_power_w
+        name,
+        model,
+        split_power_w=split_power_w,
+        loop_geometry=loop_geometry,
     )
 
 
 def _make_rooms(
     n: int,
     params: RCParams,
-    ufh_max_power_w: float = 5000.0,
+    *,
+    loop_geometry: LoopGeometry | None = None,
 ) -> list[SimulatedRoom]:
     """Create *n* rooms with distinct names and identical RC parameters."""
     return [
-        _make_room(f"room_{i}", params, ufh_max_power_w=ufh_max_power_w)
-        for i in range(n)
+        _make_room(f"room_{i}", params, loop_geometry=loop_geometry) for i in range(n)
     ]
 
 
@@ -133,7 +151,7 @@ class TestFullPipelineIntegration:
         log record count, per-room filtering, finite temps, and that
         heated rooms are warmer than unheated ones.
         """
-        rooms = _make_rooms(8, params, ufh_max_power_w=3000.0)
+        rooms = _make_rooms(8, params)
         noise = SensorNoise(std=0.1, seed=42)
         cwu_cycle = CWUCycle(start_minute=0, duration_minutes=30, interval_minutes=480)
         sim = BuildingSimulator(
@@ -197,7 +215,7 @@ class TestFullPipelineIntegration:
         Verifies performance, log integrity, and finite temperatures
         across a full-week simulation with all features enabled.
         """
-        rooms = _make_rooms(4, params, ufh_max_power_w=4000.0)
+        rooms = _make_rooms(4, params)
         noise = SensorNoise(std=0.05, seed=99)
         cwu_cycle = CWUCycle(start_minute=0, duration_minutes=20, interval_minutes=360)
         sim = BuildingSimulator(
@@ -266,7 +284,7 @@ class TestCWUInterruptMultiRoom:
         simulation run with valve=0 and no CWU schedule.
         """
         # CWU simulator: valve=100 but CWU active for 30 steps
-        rooms_cwu = _make_rooms(2, params, ufh_max_power_w=5000.0)
+        rooms_cwu = _make_rooms(2, params)
         cwu_cycle = CWUCycle(start_minute=0, duration_minutes=30, interval_minutes=0)
         sim_cwu = BuildingSimulator(
             rooms_cwu,
@@ -276,7 +294,7 @@ class TestCWUInterruptMultiRoom:
         )
 
         # Reference simulator: valve=0, no CWU
-        rooms_ref = _make_rooms(2, params, ufh_max_power_w=5000.0)
+        rooms_ref = _make_rooms(2, params)
         sim_ref = BuildingSimulator(
             rooms_ref,
             constant_weather,
@@ -317,7 +335,7 @@ class TestCWUInterruptMultiRoom:
         Verifies that both CWU interrupts and sensor noise work together
         in multi-room mode without interfering.
         """
-        rooms = _make_rooms(2, params, ufh_max_power_w=5000.0)
+        rooms = _make_rooms(2, params)
         noise = SensorNoise(std=0.5, seed=42)
         # CWU active for first 10 steps, then off
         cwu_cycle = CWUCycle(start_minute=0, duration_minutes=10, interval_minutes=0)
@@ -330,7 +348,7 @@ class TestCWUInterruptMultiRoom:
         )
 
         # Reference for CWU period: valve=0, same noise seed
-        rooms_ref = _make_rooms(2, params, ufh_max_power_w=5000.0)
+        rooms_ref = _make_rooms(2, params)
         sim_ref = BuildingSimulator(
             rooms_ref,
             constant_weather,
@@ -387,7 +405,7 @@ class TestCWUInterruptMultiRoom:
         _distribute_hp_power receives all-zero demands and returns
         all-zero allocations.
         """
-        rooms = _make_rooms(3, params, ufh_max_power_w=5000.0)
+        rooms = _make_rooms(3, params)
         cwu_cycle = CWUCycle(start_minute=0, duration_minutes=100, interval_minutes=0)
         sim = BuildingSimulator(
             rooms,
@@ -399,7 +417,7 @@ class TestCWUInterruptMultiRoom:
         # CWU is active: all valves should be zeroed internally
         # We can verify by checking that all rooms cool identically
         # to a zero-valve reference
-        rooms_ref = _make_rooms(3, params, ufh_max_power_w=5000.0)
+        rooms_ref = _make_rooms(3, params)
         sim_ref = BuildingSimulator(
             rooms_ref,
             constant_weather,
@@ -447,13 +465,11 @@ class TestCWUInterruptMultiRoom:
             _make_room(
                 "room_0",
                 params_mimo,
-                ufh_max_power_w=5000.0,
                 split_power_w=2500.0,
             ),
             _make_room(
                 "room_1",
                 params_mimo,
-                ufh_max_power_w=5000.0,
                 split_power_w=2500.0,
             ),
         ]
@@ -470,13 +486,11 @@ class TestCWUInterruptMultiRoom:
             _make_room(
                 "room_0",
                 params_mimo,
-                ufh_max_power_w=5000.0,
                 split_power_w=2500.0,
             ),
             _make_room(
                 "room_1",
                 params_mimo,
-                ufh_max_power_w=5000.0,
                 split_power_w=2500.0,
             ),
         ]
@@ -546,7 +560,7 @@ class TestSensorNoiseMultiRoom:
         applies sensor noise to T_room and T_slab.  The underlying
         physics state must remain unaffected by noise.
         """
-        rooms = _make_rooms(2, params, ufh_max_power_w=5000.0)
+        rooms = _make_rooms(2, params)
         noise = SensorNoise(std=0.5, seed=42)
         sim = BuildingSimulator(
             rooms,
@@ -599,7 +613,7 @@ class TestSensorNoiseMultiRoom:
         """
 
         def run_sim(seed: int) -> list[float]:
-            rooms = _make_rooms(2, params, ufh_max_power_w=5000.0)
+            rooms = _make_rooms(2, params)
             noise = SensorNoise(std=0.5, seed=seed)
             sim = BuildingSimulator(
                 rooms,
@@ -649,7 +663,7 @@ class TestSimulationLogRecords:
         to the log, the record's convenience properties must match the
         original measurement values.
         """
-        rooms = _make_rooms(2, params, ufh_max_power_w=5000.0)
+        rooms = _make_rooms(2, params)
         noise = SensorNoise(std=0.1, seed=42)
         sim = BuildingSimulator(
             rooms,

--- a/tests/unit/test_epic04_integration.py
+++ b/tests/unit/test_epic04_integration.py
@@ -60,15 +60,10 @@ def _build_simulator_from_scenario(scenario: SimScenario) -> BuildingSimulator:
     rooms: list[SimulatedRoom] = []
     for room_cfg in scenario.building.rooms:
         model = RCModel(room_cfg.params, ModelOrder.THREE, dt=scenario.dt_seconds)
-        try:
-            geometry = LoopGeometry.from_room_config(room_cfg)
-        except ValueError:
-            geometry = None
+        geometry = LoopGeometry.from_room_config(room_cfg)
         sim_room = SimulatedRoom(
             room_cfg.name,
             model,
-            ufh_max_power_w=room_cfg.ufh_max_power_w,
-            ufh_cooling_max_power_w=room_cfg.ufh_cooling_max_power_w,
             split_power_w=room_cfg.split_power_w,
             q_int_w=room_cfg.q_int_w,
             loop_geometry=geometry,
@@ -262,13 +257,13 @@ class TestSplitConsistencyAcrossModules:
         building = modern_bungalow()
         for room_cfg in building.rooms:
             model = RCModel(room_cfg.params, ModelOrder.THREE, dt=60.0)
+            geometry = LoopGeometry.from_room_config(room_cfg)
             sim_room = SimulatedRoom(
                 room_cfg.name,
                 model,
-                ufh_max_power_w=room_cfg.ufh_max_power_w,
-                ufh_cooling_max_power_w=room_cfg.ufh_cooling_max_power_w,
                 split_power_w=room_cfg.split_power_w,
                 q_int_w=room_cfg.q_int_w,
+                loop_geometry=geometry,
             )
             if room_cfg.has_split:
                 assert sim_room.has_split, (

--- a/tests/unit/test_epic05_integration.py
+++ b/tests/unit/test_epic05_integration.py
@@ -127,7 +127,7 @@ class TestEpic05Integration:
         m = SimMetrics.from_log(
             log,
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
 
@@ -276,13 +276,13 @@ class TestEpic05Integration:
         m_good = SimMetrics.from_log(
             _make_log(good_records),
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         m_bad = SimMetrics.from_log(
             _make_log(bad_records),
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
 
@@ -323,7 +323,7 @@ class TestEpic05Integration:
             test_log_same,
             baseline_log,
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
 
@@ -338,7 +338,7 @@ class TestEpic05Integration:
                 excess_log,
                 baseline_log,
                 setpoint=21.0,
-                ufh_max_power_w=5000.0,
+                ufh_nominal_power_w=5000.0,
                 split_power_w=2500.0,
             )
 

--- a/tests/unit/test_epic06_integration.py
+++ b/tests/unit/test_epic06_integration.py
@@ -206,7 +206,7 @@ class TestSerializeThenVisualize:
             loaded,
             setpoint=21.0,
             comfort_band=0.5,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         assert fig is not None

--- a/tests/unit/test_epic10_integration.py
+++ b/tests/unit/test_epic10_integration.py
@@ -42,7 +42,20 @@ from pumpahead.optimizer import (
 )
 from pumpahead.scenarios import cold_snap, steady_state
 from pumpahead.simulation_log import SimulationLog
+from pumpahead.ufh_loop import LoopGeometry
 from pumpahead.weather import SyntheticWeather
+
+
+def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
+    """Return a standard UFH loop geometry used throughout the tests."""
+    return LoopGeometry(
+        effective_pipe_length_m=130.0,
+        pipe_spacing_m=0.15,
+        pipe_diameter_outer_mm=16.0,
+        pipe_wall_thickness_mm=2.0,
+        area_m2=area_m2,
+    )
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -273,9 +286,9 @@ class TestControllerToSimulatorPipeline:
         room = SimulatedRoom(
             "test_room",
             sim_model,
-            ufh_max_power_w=3000.0,
             split_power_w=0.0,
             q_int_w=50.0,
+            loop_geometry=_standard_geometry(),
         )
         weather = SyntheticWeather.constant(T_out=0.0)
         sim = BuildingSimulator(
@@ -329,7 +342,7 @@ class TestControllerToSimulatorPipeline:
         metrics = SimMetrics.from_log(
             room_log,
             setpoint=21.0,
-            ufh_max_power_w=3000.0,
+            ufh_nominal_power_w=3000.0,
             split_power_w=0.0,
             dt_minutes=1,
         )

--- a/tests/unit/test_epic14_integration.py
+++ b/tests/unit/test_epic14_integration.py
@@ -461,23 +461,26 @@ class TestScenarioCoolingConfiguration:
         assert len(rooms_without_split) == 7
 
     def test_all_cooling_scenarios_have_cooling_power(self) -> None:
-        """All rooms in cooling scenarios have ufh_cooling_max_power_w > 0."""
+        """All rooms in cooling scenarios have nominal_ufh_power_cooling_w > 0."""
         scenarios = [dew_point_stress(), hot_july(), dual_source_cooling_steady()]
         for scenario in scenarios:
             for room in scenario.building.rooms:
-                assert room.ufh_cooling_max_power_w > 0, (
+                cooling = room.nominal_ufh_power_cooling_w
+                assert cooling > 0, (
                     f"Room '{room.name}' in scenario '{scenario.name}' "
-                    f"has ufh_cooling_max_power_w={room.ufh_cooling_max_power_w}"
+                    f"has nominal_ufh_power_cooling_w={cooling}"
                 )
 
     def test_cooling_power_asymmetry_in_scenarios(self) -> None:
         """Cooling power is less than heating power (asymmetric heat transfer)."""
         scenario = dew_point_stress()
         for room in scenario.building.rooms:
-            assert room.ufh_cooling_max_power_w < room.ufh_max_power_w, (
+            heating = room.nominal_ufh_power_heating_w
+            cooling = room.nominal_ufh_power_cooling_w
+            assert cooling < heating, (
                 f"Room '{room.name}': cooling power "
-                f"({room.ufh_cooling_max_power_w} W) should be less than "
-                f"heating power ({room.ufh_max_power_w} W)"
+                f"({cooling} W) should be less than "
+                f"heating power ({heating} W)"
             )
 
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -329,7 +329,7 @@ class TestSimMetricsEnergy:
         m = SimMetrics.from_log(
             log,
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
             dt_minutes=1,
         )
@@ -351,7 +351,7 @@ class TestSimMetricsEnergy:
         m = SimMetrics.from_log(
             log,
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         # Step 0: 5000 + 2500 = 7500W (peak)
@@ -366,7 +366,7 @@ class TestSimMetricsEnergy:
         m = SimMetrics.from_log(
             log,
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         assert m.floor_energy_pct == pytest.approx(100.0)
@@ -385,7 +385,7 @@ class TestSimMetricsEnergy:
         m = SimMetrics.from_log(
             log,
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         # floor: 2500W, split: 2500W -> floor_pct = 50%
@@ -399,7 +399,7 @@ class TestSimMetricsEnergy:
         m = SimMetrics.from_log(
             log,
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         assert m.energy_kwh == pytest.approx(0.0)
@@ -440,7 +440,7 @@ class TestSimMetricsEmptyLog:
         m = SimMetrics.from_log(
             log,
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         assert m.energy_kwh == pytest.approx(0.0)
@@ -515,7 +515,7 @@ class TestSimMetricsCompare:
         m_with_energy = SimMetrics.from_log(
             log,
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         diff = m_no_energy.compare(m_with_energy)
@@ -590,13 +590,13 @@ class TestSimMetricsDeterminism:
         m1 = SimMetrics.from_log(
             log,
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         m2 = SimMetrics.from_log(
             log,
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         assert m1 == m2

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -555,7 +555,6 @@ class TestParametricSweeps:
         assert lazienka.auxiliary_type == "heater"
         assert lazienka.has_split is True
         assert lazienka.split_power_w == 300.0
-        assert lazienka.ufh_cooling_max_power_w == 0.0
 
         cooling = bathroom_heater_cooling()
         assert cooling.mode == "cooling"

--- a/tests/unit/test_sensor_noise.py
+++ b/tests/unit/test_sensor_noise.py
@@ -18,6 +18,7 @@ from pumpahead.simulator import (
     BuildingSimulator,
     HeatPumpMode,
 )
+from pumpahead.ufh_loop import LoopGeometry
 from pumpahead.weather import SyntheticWeather
 
 # ---------------------------------------------------------------------------
@@ -25,10 +26,21 @@ from pumpahead.weather import SyntheticWeather
 # ---------------------------------------------------------------------------
 
 
+def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
+    """Return a standard UFH loop geometry used throughout the tests."""
+    return LoopGeometry(
+        effective_pipe_length_m=130.0,
+        pipe_spacing_m=0.15,
+        pipe_diameter_outer_mm=16.0,
+        pipe_wall_thickness_mm=2.0,
+        area_m2=area_m2,
+    )
+
+
 @pytest.fixture()
 def siso_room(model_3r3c: RCModel) -> SimulatedRoom:
-    """SISO simulated room with 5000 W UFH capacity."""
-    return SimulatedRoom("noise_test", model_3r3c, ufh_max_power_w=5000.0)
+    """SISO simulated room with standard UFH loop geometry."""
+    return SimulatedRoom("noise_test", model_3r3c, loop_geometry=_standard_geometry())
 
 
 @pytest.fixture()
@@ -185,13 +197,17 @@ class TestSensorNoiseIntegration:
 
         # Simulator WITH noise
         model_noisy = RCModel(params, order, dt=60.0)
-        room_noisy = SimulatedRoom("noisy", model_noisy, ufh_max_power_w=5000.0)
+        room_noisy = SimulatedRoom(
+            "noisy", model_noisy, loop_geometry=_standard_geometry()
+        )
         noise = SensorNoise(std=1.0, seed=42)
         sim_noisy = BuildingSimulator(room_noisy, constant_weather, sensor_noise=noise)
 
         # Simulator WITHOUT noise
         model_clean = RCModel(params, order, dt=60.0)
-        room_clean = SimulatedRoom("clean", model_clean, ufh_max_power_w=5000.0)
+        room_clean = SimulatedRoom(
+            "clean", model_clean, loop_geometry=_standard_geometry()
+        )
         sim_clean = BuildingSimulator(room_clean, constant_weather)
 
         # Run both with identical actions
@@ -227,7 +243,7 @@ class TestSensorNoiseIntegration:
 
         for _ in range(2):
             model = RCModel(params_3r3c, ModelOrder.THREE, dt=60.0)
-            room = SimulatedRoom("det", model, ufh_max_power_w=5000.0)
+            room = SimulatedRoom("det", model, loop_geometry=_standard_geometry())
             noise = SensorNoise(std=0.3, seed=42)
             sim = BuildingSimulator(room, constant_weather, sensor_noise=noise)
 

--- a/tests/unit/test_simulator_multi_room.py
+++ b/tests/unit/test_simulator_multi_room.py
@@ -13,6 +13,7 @@ from pumpahead.simulator import (
     HeatPumpMode,
     Measurements,
 )
+from pumpahead.ufh_loop import LoopGeometry, loop_power
 from pumpahead.weather import SyntheticWeather
 
 # ---------------------------------------------------------------------------
@@ -20,25 +21,44 @@ from pumpahead.weather import SyntheticWeather
 # ---------------------------------------------------------------------------
 
 
+def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
+    """Return a standard UFH loop geometry used throughout the tests."""
+    return LoopGeometry(
+        effective_pipe_length_m=130.0,
+        pipe_spacing_m=0.15,
+        pipe_diameter_outer_mm=16.0,
+        pipe_wall_thickness_mm=2.0,
+        area_m2=area_m2,
+    )
+
+
+def _nominal_heating_w(geometry: LoopGeometry, t_slab: float = 20.0) -> float:
+    """Expected ``loop_power`` at the fallback heating supply (35 C)."""
+    return loop_power(35.0, t_slab, geometry, "heating")
+
+
 def _make_room(
     name: str,
     params: RCParams,
-    ufh_max_power_w: float = 5000.0,
+    *,
+    loop_geometry: LoopGeometry | None = None,
 ) -> SimulatedRoom:
     """Create a SimulatedRoom with a 3R3C model at dt=60s."""
     model = RCModel(params, ModelOrder.THREE, dt=60.0)
-    return SimulatedRoom(name, model, ufh_max_power_w=ufh_max_power_w)
+    if loop_geometry is None:
+        loop_geometry = _standard_geometry()
+    return SimulatedRoom(name, model, loop_geometry=loop_geometry)
 
 
 def _make_rooms(
     n: int,
     params: RCParams,
-    ufh_max_power_w: float = 5000.0,
+    *,
+    loop_geometry: LoopGeometry | None = None,
 ) -> list[SimulatedRoom]:
     """Create *n* rooms with distinct names and identical RC parameters."""
     return [
-        _make_room(f"room_{i}", params, ufh_max_power_w=ufh_max_power_w)
-        for i in range(n)
+        _make_room(f"room_{i}", params, loop_geometry=loop_geometry) for i in range(n)
     ]
 
 
@@ -78,7 +98,12 @@ def constant_weather() -> SyntheticWeather:
 
 
 class TestHPPowerDistribution:
-    """Tests for the HP power distribution algorithm."""
+    """Tests for the HP power distribution algorithm.
+
+    Post-#144 the distributor uses ``loop_power(T_supply, T_slab,
+    geometry, mode)`` instead of the legacy proportional law — the test
+    expectations reference the physical model directly.
+    """
 
     @pytest.mark.unit
     def test_equal_valves_equal_power(
@@ -86,19 +111,24 @@ class TestHPPowerDistribution:
         params: RCParams,
         constant_weather: SyntheticWeather,
     ) -> None:
-        """Two rooms with equal valve and equal ufh_max get equal power."""
-        rooms = _make_rooms(2, params, ufh_max_power_w=5000.0)
-        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=6000.0)
+        """Two rooms with equal geometry and equal valve get equal power."""
+        geom = _standard_geometry()
+        rooms = _make_rooms(2, params, loop_geometry=geom)
+        q_nom = _nominal_heating_w(geom)
+        # Undersized HP so scaling path is exercised; expected = HP/2.
+        hp_max = 0.5 * q_nom
+        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=hp_max)
 
         actions = {
             "room_0": Actions(valve_position=50.0),
             "room_1": Actions(valve_position=50.0),
         }
-        # Each room demands 50% * 5000 = 2500 W.  Total = 5000 <= 6000.
         allocated = sim._distribute_hp_power(actions)
 
-        assert allocated["room_0"] == pytest.approx(2500.0)
-        assert allocated["room_1"] == pytest.approx(2500.0)
+        # Each room demands 50% * q_nom; total = q_nom > hp_max.
+        # Scale = hp_max / total = hp_max / q_nom; per-room = hp_max/2.
+        assert allocated["room_0"] == pytest.approx(hp_max / 2.0)
+        assert allocated["room_1"] == pytest.approx(hp_max / 2.0)
 
     @pytest.mark.unit
     def test_unequal_valves_proportional_power(
@@ -107,18 +137,22 @@ class TestHPPowerDistribution:
         constant_weather: SyntheticWeather,
     ) -> None:
         """With constrained HP, rooms get power proportional to demand."""
-        rooms = _make_rooms(2, params, ufh_max_power_w=5000.0)
-        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=3000.0)
+        geom = _standard_geometry()
+        rooms = _make_rooms(2, params, loop_geometry=geom)
+        q_nom = _nominal_heating_w(geom)
+        # 100% + 50% valves -> demand 1.5 * q_nom; HP = 0.4 * that.
+        total_demand = 1.5 * q_nom
+        hp_max = 0.4 * total_demand
+        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=hp_max)
 
         actions = {
-            "room_0": Actions(valve_position=100.0),  # demands 5000 W
-            "room_1": Actions(valve_position=50.0),  # demands 2500 W
+            "room_0": Actions(valve_position=100.0),
+            "room_1": Actions(valve_position=50.0),
         }
-        # Total demand = 7500, HP = 3000, scale = 3000/7500 = 0.4
         allocated = sim._distribute_hp_power(actions)
 
-        assert allocated["room_0"] == pytest.approx(5000.0 * 0.4)
-        assert allocated["room_1"] == pytest.approx(2500.0 * 0.4)
+        assert allocated["room_0"] == pytest.approx(1.0 * q_nom * 0.4)
+        assert allocated["room_1"] == pytest.approx(0.5 * q_nom * 0.4)
 
     @pytest.mark.unit
     def test_all_valves_zero_gives_zero_power(
@@ -142,17 +176,20 @@ class TestHPPowerDistribution:
         params: RCParams,
         constant_weather: SyntheticWeather,
     ) -> None:
-        """One open valve with undersized HP gets the HP limit, not ufh_max."""
-        rooms = _make_rooms(2, params, ufh_max_power_w=5000.0)
-        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=3000.0)
+        """One open valve with undersized HP gets the HP limit, not Q_nom."""
+        geom = _standard_geometry()
+        rooms = _make_rooms(2, params, loop_geometry=geom)
+        q_nom = _nominal_heating_w(geom)
+        hp_max = 0.5 * q_nom  # deliberately below Q_nom
+        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=hp_max)
 
         actions = {
-            "room_0": Actions(valve_position=100.0),  # demands 5000 W
-            "room_1": Actions(valve_position=0.0),  # demands 0 W
+            "room_0": Actions(valve_position=100.0),  # demands q_nom
+            "room_1": Actions(valve_position=0.0),  # demands 0
         }
         allocated = sim._distribute_hp_power(actions)
 
-        assert allocated["room_0"] == pytest.approx(3000.0)
+        assert allocated["room_0"] == pytest.approx(hp_max)
         assert allocated["room_1"] == 0.0
 
     @pytest.mark.unit
@@ -162,17 +199,20 @@ class TestHPPowerDistribution:
         constant_weather: SyntheticWeather,
     ) -> None:
         """When total demand is below HP capacity, each room gets full demand."""
-        rooms = _make_rooms(2, params, ufh_max_power_w=2000.0)
-        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=6000.0)
+        geom = _standard_geometry()
+        rooms = _make_rooms(2, params, loop_geometry=geom)
+        q_nom = _nominal_heating_w(geom)
+        hp_max = 10.0 * q_nom  # generously oversized
+        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=hp_max)
 
         actions = {
-            "room_0": Actions(valve_position=100.0),  # demands 2000 W
-            "room_1": Actions(valve_position=50.0),  # demands 1000 W
+            "room_0": Actions(valve_position=100.0),
+            "room_1": Actions(valve_position=50.0),
         }
         allocated = sim._distribute_hp_power(actions)
 
-        assert allocated["room_0"] == pytest.approx(2000.0)
-        assert allocated["room_1"] == pytest.approx(1000.0)
+        assert allocated["room_0"] == pytest.approx(1.0 * q_nom)
+        assert allocated["room_1"] == pytest.approx(0.5 * q_nom)
 
     @pytest.mark.unit
     def test_energy_conservation(
@@ -181,15 +221,17 @@ class TestHPPowerDistribution:
         constant_weather: SyntheticWeather,
     ) -> None:
         """Sum of allocated power equals HP capacity when demand exceeds it."""
-        rooms = _make_rooms(4, params, ufh_max_power_w=5000.0)
-        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=6000.0)
+        geom = _standard_geometry()
+        rooms = _make_rooms(4, params, loop_geometry=geom)
+        q_nom = _nominal_heating_w(geom)
+        hp_max = 0.3 * 4.0 * q_nom  # HP covers 30% of total demand
+        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=hp_max)
 
         actions = {r.name: Actions(valve_position=100.0) for r in rooms}
-        # Total demand = 4 * 5000 = 20000, HP = 6000
         allocated = sim._distribute_hp_power(actions)
 
         total_allocated = sum(allocated.values())
-        assert total_allocated == pytest.approx(6000.0)
+        assert total_allocated == pytest.approx(hp_max)
 
     @pytest.mark.unit
     def test_energy_conservation_under_capacity(
@@ -198,17 +240,20 @@ class TestHPPowerDistribution:
         constant_weather: SyntheticWeather,
     ) -> None:
         """Sum of allocated power equals total demand when within capacity."""
-        rooms = _make_rooms(2, params, ufh_max_power_w=1000.0)
-        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=6000.0)
+        geom = _standard_geometry()
+        rooms = _make_rooms(2, params, loop_geometry=geom)
+        q_nom = _nominal_heating_w(geom)
+        hp_max = 10.0 * q_nom  # generously oversized
+        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=hp_max)
 
         actions = {
-            "room_0": Actions(valve_position=80.0),  # demands 800 W
-            "room_1": Actions(valve_position=60.0),  # demands 600 W
+            "room_0": Actions(valve_position=80.0),
+            "room_1": Actions(valve_position=60.0),
         }
         allocated = sim._distribute_hp_power(actions)
 
         total_allocated = sum(allocated.values())
-        assert total_allocated == pytest.approx(1400.0)
+        assert total_allocated == pytest.approx((0.8 + 0.6) * q_nom)
 
     @pytest.mark.unit
     def test_unlimited_hp_no_scaling(
@@ -217,39 +262,47 @@ class TestHPPowerDistribution:
         constant_weather: SyntheticWeather,
     ) -> None:
         """With hp_max_power_w=None (unlimited), each room gets full demand."""
-        rooms = _make_rooms(4, params, ufh_max_power_w=5000.0)
+        geom = _standard_geometry()
+        rooms = _make_rooms(4, params, loop_geometry=geom)
+        q_nom = _nominal_heating_w(geom)
         sim = BuildingSimulator(rooms, constant_weather)  # no hp_max_power_w
 
         actions = {r.name: Actions(valve_position=100.0) for r in rooms}
         allocated = sim._distribute_hp_power(actions)
 
         for name in allocated:
-            assert allocated[name] == pytest.approx(5000.0)
+            assert allocated[name] == pytest.approx(q_nom)
 
     @pytest.mark.unit
-    def test_rooms_with_different_ufh_max(
+    def test_rooms_with_different_geometry(
         self,
         params: RCParams,
         constant_weather: SyntheticWeather,
     ) -> None:
-        """Rooms with different ufh_max_power_w get proportional shares."""
-        room_a = _make_room("room_a", params, ufh_max_power_w=5000.0)
-        room_b = _make_room("room_b", params, ufh_max_power_w=2000.0)
+        """Rooms with different geometries get proportional shares."""
+        # Two geometries with different area -> different nominal powers.
+        geom_a = _standard_geometry(area_m2=30.0)
+        geom_b = _standard_geometry(area_m2=12.0)
+        room_a = _make_room("room_a", params, loop_geometry=geom_a)
+        room_b = _make_room("room_b", params, loop_geometry=geom_b)
+        q_a = _nominal_heating_w(geom_a)
+        q_b = _nominal_heating_w(geom_b)
+        total = q_a + q_b
+        hp_max = 0.4 * total  # force scaling
         sim = BuildingSimulator(
-            [room_a, room_b], constant_weather, hp_max_power_w=3000.0
+            [room_a, room_b], constant_weather, hp_max_power_w=hp_max
         )
 
         actions = {
-            "room_a": Actions(valve_position=100.0),  # demands 5000 W
-            "room_b": Actions(valve_position=100.0),  # demands 2000 W
+            "room_a": Actions(valve_position=100.0),
+            "room_b": Actions(valve_position=100.0),
         }
-        # Total demand = 7000, scale = 3000/7000
         allocated = sim._distribute_hp_power(actions)
 
-        scale = 3000.0 / 7000.0
-        assert allocated["room_a"] == pytest.approx(5000.0 * scale)
-        assert allocated["room_b"] == pytest.approx(2000.0 * scale)
-        assert sum(allocated.values()) == pytest.approx(3000.0)
+        scale = hp_max / total
+        assert allocated["room_a"] == pytest.approx(q_a * scale)
+        assert allocated["room_b"] == pytest.approx(q_b * scale)
+        assert sum(allocated.values()) == pytest.approx(hp_max)
 
 
 # ---------------------------------------------------------------------------
@@ -386,14 +439,16 @@ class TestBuildingSimulatorMultiRoom:
         constant_weather: SyntheticWeather,
     ) -> None:
         """After step_all, total distributed power = HP capacity (when exceeded)."""
-        rooms = _make_rooms(4, params, ufh_max_power_w=5000.0)
-        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=6000.0)
+        geom = _standard_geometry()
+        rooms = _make_rooms(4, params, loop_geometry=geom)
+        q_nom = _nominal_heating_w(geom)
+        hp_max = 0.3 * 4.0 * q_nom  # HP covers 30% of total demand
+        sim = BuildingSimulator(rooms, constant_weather, hp_max_power_w=hp_max)
 
         actions = {r.name: Actions(valve_position=100.0) for r in rooms}
-        # Total demand = 20000 > 6000, so total allocated = 6000
         allocated = sim._distribute_hp_power(actions)
 
-        assert sum(allocated.values()) == pytest.approx(6000.0)
+        assert sum(allocated.values()) == pytest.approx(hp_max)
 
     @pytest.mark.unit
     def test_backward_compat_single_room(

--- a/tests/unit/test_simulator_single_room.py
+++ b/tests/unit/test_simulator_single_room.py
@@ -15,27 +15,39 @@ from pumpahead.simulator import (
     Measurements,
     SplitMode,
 )
-from pumpahead.weather import SyntheticWeather, WeatherPoint
+from pumpahead.ufh_loop import LoopGeometry
+from pumpahead.weather import SyntheticWeather
 
 # ---------------------------------------------------------------------------
 # Local fixtures
 # ---------------------------------------------------------------------------
 
 
+def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
+    """Return a standard UFH loop geometry used throughout the tests."""
+    return LoopGeometry(
+        effective_pipe_length_m=130.0,
+        pipe_spacing_m=0.15,
+        pipe_diameter_outer_mm=16.0,
+        pipe_wall_thickness_mm=2.0,
+        area_m2=area_m2,
+    )
+
+
 @pytest.fixture()
 def simulated_room(model_3r3c: RCModel) -> SimulatedRoom:
-    """SISO simulated room with 5000 W UFH capacity."""
-    return SimulatedRoom("test_room", model_3r3c, ufh_max_power_w=5000.0)
+    """SISO simulated room with standard UFH loop geometry."""
+    return SimulatedRoom("test_room", model_3r3c, loop_geometry=_standard_geometry())
 
 
 @pytest.fixture()
 def simulated_room_mimo(model_3r3c_mimo: RCModel) -> SimulatedRoom:
-    """MIMO simulated room with 5000 W UFH and 2500 W split."""
+    """MIMO simulated room with 2500 W split and standard UFH loop."""
     return SimulatedRoom(
         "test_room_mimo",
         model_3r3c_mimo,
-        ufh_max_power_w=5000.0,
         split_power_w=2500.0,
+        loop_geometry=_standard_geometry(),
     )
 
 
@@ -77,11 +89,15 @@ class TestSimulatedRoom:
         assert simulated_room.T_slab == 22.0
 
     @pytest.mark.unit
-    def test_step_propagates_temperature(self, simulated_room: SimulatedRoom) -> None:
+    def test_step_propagates_temperature(
+        self,
+        simulated_room: SimulatedRoom,
+        constant_weather: SyntheticWeather,
+    ) -> None:
         """Stepping with cold weather and no heating cools the room."""
-        wp = WeatherPoint(T_out=-5.0, GHI=0.0, wind_speed=0.0, humidity=50.0)
+        sim = BuildingSimulator(simulated_room, constant_weather)
         initial_t_air = simulated_room.T_air
-        simulated_room.step(wp, q_sol_w=0.0)
+        sim.step(Actions(valve_position=0.0))
         # Room should cool: T_out=-5 < T_initial=20
         assert simulated_room.T_air < initial_t_air
 
@@ -98,13 +114,16 @@ class TestSimulatedRoom:
         assert simulated_room.valve_position == 0.0
 
     @pytest.mark.unit
-    def test_valve_drives_slab_heating(self, simulated_room: SimulatedRoom) -> None:
-        """100 % valve heats the slab over 100 steps."""
-        simulated_room.apply_actions(valve_position=100.0)
-        wp = WeatherPoint(T_out=-5.0, GHI=0.0, wind_speed=0.0, humidity=50.0)
+    def test_valve_drives_slab_heating(
+        self,
+        simulated_room: SimulatedRoom,
+        constant_weather: SyntheticWeather,
+    ) -> None:
+        """100 % valve heats the slab over 100 steps via the simulator."""
+        sim = BuildingSimulator(simulated_room, constant_weather)
         initial_t_slab = simulated_room.T_slab
         for _ in range(100):
-            simulated_room.step(wp, q_sol_w=0.0)
+            sim.step(Actions(valve_position=100.0))
         assert simulated_room.T_slab > initial_t_slab
 
     @pytest.mark.unit
@@ -112,26 +131,30 @@ class TestSimulatedRoom:
         self,
         model_3r3c: RCModel,
         simulated_room: SimulatedRoom,
+        constant_weather: SyntheticWeather,
     ) -> None:
-        """With valve=0, room output matches RCModel with u=[0]."""
-        wp = WeatherPoint(T_out=-5.0, GHI=0.0, wind_speed=0.0, humidity=50.0)
-
-        # Direct model step
+        """With valve=0, Q_floor=0 so the state matches RCModel.step(u=[0])."""
+        # Direct model step — reference expected state with u=[0].
         x0 = model_3r3c.reset()
         u = np.array([0.0])
+        wp = constant_weather.get(0.0)
         d = np.array([wp.T_out, 0.0, 0.0])
         x_expected = model_3r3c.step(x0, u, d)
 
-        # SimulatedRoom step
-        simulated_room.apply_actions(valve_position=0.0)
-        simulated_room.step(wp, q_sol_w=0.0)
+        # BuildingSimulator step with valve=0 -> Q_floor=0 via loop_power.
+        sim = BuildingSimulator(simulated_room, constant_weather)
+        sim.step(Actions(valve_position=0.0))
 
         np.testing.assert_array_equal(simulated_room.state, x_expected)
 
     @pytest.mark.unit
-    def test_mimo_split_heating(self, simulated_room_mimo: SimulatedRoom) -> None:
+    def test_mimo_split_heating(
+        self,
+        simulated_room_mimo: SimulatedRoom,
+        constant_weather: SyntheticWeather,
+    ) -> None:
         """MIMO room with split heating warms T_air faster than without."""
-        # Room without split
+        # Reference SISO room without split — same geometry.
         params_siso = RCParams(
             C_air=60_000,
             C_slab=3_250_000,
@@ -147,42 +170,58 @@ class TestSimulatedRoom:
             has_split=False,
         )
         model_siso = RCModel(params_siso, ModelOrder.THREE, dt=60.0)
-        room_siso = SimulatedRoom("siso", model_siso, ufh_max_power_w=5000.0)
+        room_siso = SimulatedRoom(
+            "siso", model_siso, loop_geometry=_standard_geometry()
+        )
+        sim_siso = BuildingSimulator(room_siso, constant_weather)
+        sim_mimo = BuildingSimulator(
+            simulated_room_mimo, constant_weather, split_power_w=2500.0
+        )
 
-        wp = WeatherPoint(T_out=-5.0, GHI=0.0, wind_speed=0.0, humidity=50.0)
-
-        # Both rooms: same valve, but MIMO also has split
-        room_siso.apply_actions(valve_position=50.0)
-        simulated_room_mimo.apply_actions(valve_position=50.0, split_power_w=2500.0)
-
+        # Both rooms: same valve, MIMO also has split heating on.
         for _ in range(50):
-            room_siso.step(wp, q_sol_w=0.0)
-            simulated_room_mimo.step(wp, q_sol_w=0.0)
+            sim_siso.step(Actions(valve_position=50.0))
+            sim_mimo.step(
+                Actions(
+                    valve_position=50.0,
+                    split_mode=SplitMode.HEATING,
+                    split_setpoint=21.0,
+                )
+            )
 
-        # MIMO room with split should be warmer
+        # MIMO room with split should be warmer.
         assert simulated_room_mimo.T_air > room_siso.T_air
 
     @pytest.mark.unit
     def test_siso_ignores_split_power(
         self,
-        model_3r3c: RCModel,
         simulated_room: SimulatedRoom,
+        constant_weather: SyntheticWeather,
     ) -> None:
         """SISO room silently ignores split power (Q_conv=0)."""
-        wp = WeatherPoint(T_out=-5.0, GHI=0.0, wind_speed=0.0, humidity=50.0)
+        # Build a second identical SISO room that NEVER asks for a split.
+        model_ref = RCModel(
+            simulated_room._model.params,  # noqa: SLF001 — same params
+            ModelOrder.THREE,
+            dt=60.0,
+        )
+        room_ref = SimulatedRoom("ref", model_ref, loop_geometry=_standard_geometry())
 
-        # Apply split power to SISO room -- should be ignored
-        simulated_room.apply_actions(valve_position=50.0, split_power_w=2000.0)
+        sim_a = BuildingSimulator(simulated_room, constant_weather)
+        sim_b = BuildingSimulator(room_ref, constant_weather)
 
-        # Direct model step with no split
-        x0 = model_3r3c.reset()
-        q_floor = 50.0 / 100.0 * 5000.0
-        u = np.array([q_floor])
-        d = np.array([wp.T_out, 0.0, 0.0])
-        x_expected = model_3r3c.step(x0, u, d)
+        # sim_a requests split heating (should be ignored — no has_split).
+        # sim_b requests no split.
+        sim_a.step(
+            Actions(
+                valve_position=50.0,
+                split_mode=SplitMode.HEATING,
+                split_setpoint=21.0,
+            )
+        )
+        sim_b.step(Actions(valve_position=50.0))
 
-        simulated_room.step(wp, q_sol_w=0.0)
-        np.testing.assert_array_equal(simulated_room.state, x_expected)
+        np.testing.assert_array_equal(simulated_room.state, room_ref.state)
 
     @pytest.mark.unit
     def test_state_copy_independence(self, simulated_room: SimulatedRoom) -> None:
@@ -294,7 +333,7 @@ class TestBuildingSimulatorSingleRoom:
         constant_weather: SyntheticWeather,
     ) -> None:
         """Simulator output matches direct RCModel.step() exactly."""
-        room = SimulatedRoom("test", model_3r3c, ufh_max_power_w=5000.0)
+        room = SimulatedRoom("test", model_3r3c, loop_geometry=_standard_geometry())
         sim = BuildingSimulator(room, constant_weather)
 
         # Direct model step
@@ -317,7 +356,7 @@ class TestBuildingSimulatorSingleRoom:
         constant_weather: SyntheticWeather,
     ) -> None:
         """1440 steps complete in under 100 ms wall-clock time."""
-        room = SimulatedRoom("perf", model_3r3c, ufh_max_power_w=5000.0)
+        room = SimulatedRoom("perf", model_3r3c, loop_geometry=_standard_geometry())
         sim = BuildingSimulator(room, constant_weather)
         actions = Actions(valve_position=50.0)
 
@@ -340,7 +379,7 @@ class TestBuildingSimulatorSingleRoom:
 
         for _ in range(2):
             model = RCModel(params_3r3c, ModelOrder.THREE, dt=60.0)
-            room = SimulatedRoom("det", model, ufh_max_power_w=5000.0)
+            room = SimulatedRoom("det", model, loop_geometry=_standard_geometry())
             sim = BuildingSimulator(room, constant_weather)
             run_results: list[Measurements] = []
             for step in range(1440):
@@ -366,7 +405,7 @@ class TestBuildingSimulatorSingleRoom:
             amplitude=15.0,
             step_time_minutes=60.0,
         )
-        room = SimulatedRoom("wx", model_3r3c, ufh_max_power_w=5000.0)
+        room = SimulatedRoom("wx", model_3r3c, loop_geometry=_standard_geometry())
         sim = BuildingSimulator(room, weather)
 
         # Before the step (t=0..59 => T_out=-10)
@@ -405,7 +444,7 @@ class TestBuildingSimulatorSingleRoom:
     ) -> None:
         """With T_out=-15 and no heating, T_air drops from 20 degC."""
         weather = SyntheticWeather.constant(T_out=-15.0, GHI=0.0)
-        room = SimulatedRoom("cold", model_3r3c, ufh_max_power_w=5000.0)
+        room = SimulatedRoom("cold", model_3r3c, loop_geometry=_standard_geometry())
         sim = BuildingSimulator(room, weather)
 
         initial_t_air = room.T_air
@@ -421,7 +460,7 @@ class TestBuildingSimulatorSingleRoom:
     ) -> None:
         """After many steps with constant inputs, T_air converges."""
         weather = SyntheticWeather.constant(T_out=0.0, GHI=0.0)
-        room = SimulatedRoom("steady", model_3r3c, ufh_max_power_w=5000.0)
+        room = SimulatedRoom("steady", model_3r3c, loop_geometry=_standard_geometry())
         sim = BuildingSimulator(room, weather)
 
         actions = Actions(valve_position=50.0)

--- a/tests/unit/test_simulator_ufh_physical.py
+++ b/tests/unit/test_simulator_ufh_physical.py
@@ -1,15 +1,15 @@
 """Unit tests for the physical UFH power distribution in BuildingSimulator.
 
 Covers ``BuildingSimulator._distribute_hp_power`` after the rewrite for
-issue #143 — now driven by ``pumpahead.ufh_loop.loop_power`` with a
-weather-compensation-derived ``T_supply`` instead of the legacy
-``valve * ufh_max_power_w`` proportional law.
+issue #143 and the clean-break field removal in issue #144 — now driven
+exclusively by ``pumpahead.ufh_loop.loop_power`` with a
+weather-compensation-derived ``T_supply``.  The legacy proportional
+fallback shim was deleted by #144, so every room must carry
+``loop_geometry``.
 
-Three test classes:
+Two test classes:
 
 * ``TestPhysicalDistribution`` — rooms with explicit ``loop_geometry``.
-* ``TestFallbackShim`` — rooms without geometry (legacy path still
-  works; shim will be removed by issue #144).
 * ``TestDiagnostics`` — ``last_step_info`` surface exposes ``T_supply``
   and per-room ``Q_floor`` correctly.
 """
@@ -67,17 +67,15 @@ def _standard_geometry(area_m2: float = 20.0) -> LoopGeometry:
 def _make_room(
     name: str,
     *,
-    ufh_max_power_w: float = 5000.0,
-    ufh_cooling_max_power_w: float = 3000.0,
     loop_geometry: LoopGeometry | None = None,
 ) -> SimulatedRoom:
     """Create a ``SimulatedRoom`` suitable for distributor tests."""
     model = RCModel(_standard_params(), ModelOrder.THREE, dt=60.0)
+    if loop_geometry is None:
+        loop_geometry = _standard_geometry()
     return SimulatedRoom(
         name,
         model,
-        ufh_max_power_w=ufh_max_power_w,
-        ufh_cooling_max_power_w=ufh_cooling_max_power_w,
         loop_geometry=loop_geometry,
     )
 
@@ -440,113 +438,27 @@ class TestPhysicalDistribution:
 
 
 # ---------------------------------------------------------------------------
-# TestFallbackShim — rooms WITHOUT geometry (legacy path)
+# TestGeometryRequired — every room must carry loop_geometry (#144)
 # ---------------------------------------------------------------------------
 
 
-class TestFallbackShim:
-    """Tests for the legacy valve * ufh_max_power_w shim path."""
+class TestGeometryRequired:
+    """Issue #144 removes the legacy shim — geometry is now mandatory."""
 
     @pytest.mark.unit
-    def test_legacy_heating_without_geometry(
+    def test_missing_geometry_raises(
         self,
         cold_weather: SyntheticWeather,
     ) -> None:
-        """Heating without geometry -> valve * ufh_max_power_w."""
-        # No loop_geometry -> shim path.
-        rooms = [
-            _make_room("r0", ufh_max_power_w=4000.0, loop_geometry=None),
-            _make_room("r1", ufh_max_power_w=4000.0, loop_geometry=None),
-        ]
-        sim = BuildingSimulator(
-            rooms,
-            cold_weather,
-            hp_mode=HeatPumpMode.HEATING,
-            hp_max_power_w=20_000.0,
-        )
-
-        allocated = sim._distribute_hp_power(
-            {
-                "r0": Actions(valve_position=50.0),
-                "r1": Actions(valve_position=100.0),
-            },
-        )
-
-        assert allocated["r0"] == pytest.approx(0.5 * 4000.0)
-        assert allocated["r1"] == pytest.approx(1.0 * 4000.0)
-
-    @pytest.mark.unit
-    def test_legacy_cooling_without_geometry(
-        self,
-        hot_weather: SyntheticWeather,
-    ) -> None:
-        """Cooling without geometry -> negative valve * ufh_cooling_max_power_w."""
-        rooms = [
-            _make_room(
-                "r0",
-                ufh_cooling_max_power_w=2000.0,
-                loop_geometry=None,
-            ),
-            _make_room(
-                "r1",
-                ufh_cooling_max_power_w=2000.0,
-                loop_geometry=None,
-            ),
-        ]
-        sim = BuildingSimulator(
-            rooms,
-            hot_weather,
-            hp_mode=HeatPumpMode.COOLING,
-            hp_max_power_w=20_000.0,
-        )
-
-        allocated = sim._distribute_hp_power(
-            {
-                "r0": Actions(valve_position=50.0),
-                "r1": Actions(valve_position=100.0),
-            },
-        )
-
-        assert allocated["r0"] == pytest.approx(-0.5 * 2000.0)
-        assert allocated["r1"] == pytest.approx(-1.0 * 2000.0)
-
-    @pytest.mark.unit
-    def test_mixed_rooms_with_and_without_geometry(
-        self,
-        cold_weather: SyntheticWeather,
-    ) -> None:
-        """Simulator accepts a mix of physical and legacy rooms."""
-        geometry = _standard_geometry()
-        room_physical = _make_room(
-            "physical",
-            loop_geometry=geometry,
-        )
-        _set_room_slab(room_physical, t_slab=22.0)
-        room_legacy = _make_room(
-            "legacy",
-            ufh_max_power_w=3000.0,
-            loop_geometry=None,
-        )
-
-        sim = BuildingSimulator(
-            [room_physical, room_legacy],
-            cold_weather,
-            hp_mode=HeatPumpMode.HEATING,
-            hp_max_power_w=100_000.0,  # unconstrained
-        )
-
-        allocated = sim._distribute_hp_power(
-            {
-                "physical": Actions(valve_position=100.0),
-                "legacy": Actions(valve_position=50.0),
-            },
-        )
-
-        # Legacy room: exact shim result.
-        assert allocated["legacy"] == pytest.approx(0.5 * 3000.0)
-        # Physical room: positive, finite, not tied to ufh_max_power_w.
-        assert allocated["physical"] > 0.0
-        assert np.isfinite(allocated["physical"])
+        """BuildingSimulator refuses rooms without loop_geometry."""
+        model = RCModel(_standard_params(), ModelOrder.THREE, dt=60.0)
+        room_no_geom = SimulatedRoom("r0", model, loop_geometry=None)
+        with pytest.raises(ValueError, match="loop_geometry"):
+            BuildingSimulator(
+                [room_no_geom],
+                cold_weather,
+                hp_mode=HeatPumpMode.HEATING,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -373,7 +373,7 @@ class TestPlotEnergy:
         """Function returns a matplotlib Figure."""
         import matplotlib.figure
 
-        fig = plot_energy(sample_log, ufh_max_power_w=5000.0)
+        fig = plot_energy(sample_log, ufh_nominal_power_w=5000.0)
         assert isinstance(fig, matplotlib.figure.Figure)
         import matplotlib.pyplot as plt
 
@@ -385,7 +385,7 @@ class TestPlotEnergy:
         save_path = tmp_path / "energy.png"
         fig = plot_energy(
             sample_log,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
             save_path=save_path,
         )
@@ -398,7 +398,7 @@ class TestPlotEnergy:
     def test_empty_log_rejected(self, empty_log: SimulationLog) -> None:
         """Empty log raises ValueError."""
         with pytest.raises(ValueError, match="must not be empty"):
-            plot_energy(empty_log, ufh_max_power_w=5000.0)
+            plot_energy(empty_log, ufh_nominal_power_w=5000.0)
 
 
 # ---------------------------------------------------------------------------
@@ -465,7 +465,7 @@ class TestGeneratePlots:
             tmp_path,
             scenario_name="test",
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         # 1 room temp + valves + splits + weather + energy + dashboard = 6
@@ -498,7 +498,7 @@ class TestGeneratePlots:
             tmp_path,
             scenario_name="multi",
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         names = [p.name for p in paths]
@@ -538,7 +538,7 @@ class TestGeneratePlots:
             tmp_path,
             scenario_name="cold_snap",
             setpoint=21.0,
-            ufh_max_power_w=5000.0,
+            ufh_nominal_power_w=5000.0,
             split_power_w=2500.0,
         )
         names = [p.name for p in paths]


### PR DESCRIPTION
Closes #144

## Summary
- Remove legacy `ufh_max_power_w` and `ufh_cooling_max_power_w` fields from `RoomConfig` + every call site (production + tests)
- Add `RoomConfig.nominal_ufh_power_heating_w` / `nominal_ufh_power_cooling_w` as computed properties derived from `LoopGeometry` + `ufh_loop.loop_power()` (EN 1264)
- `BuildingSimulator.__init__` fails fast when any room lacks `loop_geometry`; `_distribute_hp_power` no longer has the rated-power shim branch
- Migrate `building_profiles.py` (all 13 bungalow rooms + 4 parametric profiles) to `pipe_spacing_m`; migrate ~22 test files to `loop_geometry=_standard_geometry()` + nominal computed properties
- Calibrate 3 PID scenario tests with a realistic weather-compensation curve (base 45 C @ T_out=10 C, slope 0.8 K/K, clamped [25, 55]) — the legacy "always 5 kW" shim masked real under-sizing; with the physical model, tests must supply a WCC that matches real residential HP behaviour
- Widen `test_cooling_power_roughly_60_percent_of_heating` band to [0.4, 0.7] — the legacy 0.6 multiplier was hand-picked; under EN 1264 physics the ratio lands at ~0.435

## Test plan
- [x] `rg "ufh_max_power_w|ufh_cooling_max_power_w" pumpahead/ tests/ custom_components/` returns zero hits
- [x] `pytest -m unit` — full suite PASS
- [x] `pytest -m simulation` — 79 tests PASS
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — 120 files formatted
- [x] `mypy pumpahead/` — no issues

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>