### PR TITLE
Issue #147: Add cold_snap_weather_comp scenario with realistic HP heating curve

### DIFF
--- a/pumpahead/scenarios.py
+++ b/pumpahead/scenarios.py
@@ -47,6 +47,7 @@ from pumpahead.config import (
 )
 from pumpahead.cwu_coordinator import CWU_HEAVY
 from pumpahead.weather import ChannelProfile, ProfileKind, SyntheticWeather
+from pumpahead.weather_comp import WeatherCompCurve
 
 __all__ = [
     "PARAMETRIC_SWEEPS",
@@ -54,6 +55,7 @@ __all__ = [
     "bathroom_heater",
     "bathroom_heater_cooling",
     "cold_snap",
+    "cold_snap_weather_comp",
     "cwu_heavy",
     "cwu_with_splits",
     "dew_point_stress",
@@ -194,6 +196,59 @@ def cold_snap() -> SimScenario:
         description=(
             "Step drop from 0C to -15C after 24h. "
             "Tests split entry/exit and UFH takeover."
+        ),
+    )
+
+
+def cold_snap_weather_comp() -> SimScenario:
+    """Step drop from 0C to -15C after 24h with a realistic HP heating curve.
+
+    Mirrors the :func:`cold_snap` weather profile (baseline 0 C, amplitude
+    -15 C, step at t=1440 min, constant GHI=0, wind=2, humidity=60) but
+    exercises the weather-compensation curve introduced in #141 and wired
+    in #143.  The curve uses ``t_supply_base=35`` C, ``slope=0.4``,
+    ``t_neutral=0`` C, ``t_supply_max=55`` C, ``t_supply_min=25`` C, giving
+    ~41 C supply at the -15 C cold peak (35 + 0.4 * 15).
+
+    Uses the ``modern_bungalow`` building (7 kW HP, 8 rooms, salon has
+    splits).  Duration is 48 h so the second 24 h exercises the peak
+    supply temperature.
+
+    Returns:
+        ``SimScenario`` with ``modern_bungalow`` building, 48 h duration,
+        heating mode, and a configured ``WeatherCompCurve``.
+    """
+    weather = SyntheticWeather(
+        t_out=ChannelProfile(
+            kind=ProfileKind.STEP,
+            baseline=0.0,
+            amplitude=-15.0,
+            step_time_minutes=1440.0,
+        ),
+        ghi=ChannelProfile(kind=ProfileKind.CONSTANT, baseline=0.0),
+        wind_speed=ChannelProfile(kind=ProfileKind.CONSTANT, baseline=2.0),
+        humidity=ChannelProfile(kind=ProfileKind.CONSTANT, baseline=60.0),
+    )
+    curve = WeatherCompCurve(
+        t_supply_base=35.0,
+        slope=0.4,
+        t_neutral=0.0,
+        t_supply_max=55.0,
+        t_supply_min=25.0,
+    )
+    return SimScenario(
+        name="cold_snap_weather_comp",
+        building=modern_bungalow(),
+        weather=weather,
+        controller=ControllerConfig(setpoint=21.0),
+        duration_minutes=2880,
+        mode="heating",
+        dt_seconds=60.0,
+        weather_comp=curve,
+        description=(
+            "Step drop from 0C to -15C after 24h with realistic HP "
+            "heating curve (base=35C, slope=0.4, neutral=0C). "
+            "Tests weather-compensation under severe cold."
         ),
     )
 
@@ -973,6 +1028,7 @@ def screed_sweep() -> list[SimScenario]:
 SCENARIO_LIBRARY: dict[str, Callable[[], SimScenario]] = {
     "steady_state": steady_state,
     "cold_snap": cold_snap,
+    "cold_snap_weather_comp": cold_snap_weather_comp,
     "hot_july": hot_july,
     "solar_overshoot": solar_overshoot,
     "full_year_2025": full_year_2025,

--- a/tests/simulation/test_cold_snap_weather_comp.py
+++ b/tests/simulation/test_cold_snap_weather_comp.py
@@ -1,0 +1,201 @@
+"""Simulation tests for the ``cold_snap_weather_comp`` scenario.
+
+Exercises the weather-compensation curve introduced in #141 and wired
+into the simulator in #143 under a 48 h cold snap (0 C -> -15 C step at
+t=1440 min).  The scenario uses the ``modern_bungalow`` building and a
+realistic Aquarea/Daikin-style heating curve
+(``t_supply_base=35``, ``slope=0.4``, ``t_neutral=0``, ``min=25``,
+``max=55``).
+
+Tests:
+    * Comfort above 18 C in every room over the full 2880 min.
+    * Floor-temperature safety per room (Axiom #4 and Axiom #5).
+    * No freezing and no prolonged cold in the whole log.
+    * ``T_supply`` peak during the cold half (t >= 1440) ~ 41 C ± 1 C.
+    * ``T_supply`` stays within the configured min/max clamps.
+    * ``T_supply`` is monotonically non-decreasing as ``T_out`` drops.
+    * A 2-panel PNG plot of ``T_out`` and ``T_supply`` is produced.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from pumpahead.config import SimScenario
+from pumpahead.metrics import (
+    SimMetrics,
+    assert_floor_temp_safe,
+    assert_no_freezing,
+    assert_no_prolonged_cold,
+)
+from pumpahead.scenarios import cold_snap_weather_comp
+from pumpahead.simulation_log import SimulationLog
+from pumpahead.weather_comp import WeatherCompCurve
+
+
+def _curve(scenario: SimScenario) -> WeatherCompCurve:
+    """Return the scenario's heating weather-compensation curve.
+
+    Args:
+        scenario: Scenario under test.
+
+    Returns:
+        The configured :class:`WeatherCompCurve`.
+
+    Raises:
+        AssertionError: If the scenario does not have a ``weather_comp``.
+    """
+    curve = scenario.weather_comp
+    assert curve is not None, "cold_snap_weather_comp must configure weather_comp"
+    return curve
+
+
+@pytest.mark.simulation
+class TestColdSnapWeatherComp:
+    """Tests for the ``cold_snap_weather_comp`` scenario."""
+
+    def test_all_rooms_comfort_above_18c(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """Every room stays strictly above 18 C for the full 48 h."""
+        scenario = cold_snap_weather_comp()
+        log, _ = run_scenario(scenario, None)
+
+        for room_cfg in scenario.building.rooms:
+            room_log = log.get_room(room_cfg.name)
+            min_t_room = min(rec.T_room for rec in room_log)
+            assert min_t_room > 18.0, (
+                f"{room_cfg.name}: min T_room={min_t_room:.2f} C "
+                "dropped to or below 18 C"
+            )
+
+    def test_floor_temp_safe_all_rooms(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """Floor temperature stays within safe bounds in every room."""
+        scenario = cold_snap_weather_comp()
+        log, _ = run_scenario(scenario, None)
+
+        for room_cfg in scenario.building.rooms:
+            assert_floor_temp_safe(log.get_room(room_cfg.name))
+
+    def test_no_freezing_no_prolonged_cold(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """No room ever freezes (T<16) or stays below 18 C for >24 h."""
+        scenario = cold_snap_weather_comp()
+        log, _ = run_scenario(scenario, None)
+
+        assert_no_freezing(log)
+        assert_no_prolonged_cold(log)
+
+    def test_t_supply_peaks_at_41c_during_cold(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """Peak T_supply during the cold half (t >= 1440) is ~41 C ± 1 C."""
+        scenario = cold_snap_weather_comp()
+        log, _ = run_scenario(scenario, None)
+
+        curve = _curve(scenario)
+        first_room = scenario.building.rooms[0].name
+        room_log = log.get_room(first_room)
+
+        peak_t_supply = max(
+            curve.t_supply(rec.T_out) for rec in room_log if rec.t >= 1440
+        )
+        assert peak_t_supply == pytest.approx(41.0, abs=1.0), (
+            f"peak T_supply during cold half={peak_t_supply:.2f} C, "
+            "expected ~41 C ± 1 C"
+        )
+
+    def test_t_supply_within_clamps(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+    ) -> None:
+        """T_supply never falls below 25 C nor exceeds 55 C."""
+        scenario = cold_snap_weather_comp()
+        log, _ = run_scenario(scenario, None)
+
+        curve = _curve(scenario)
+        first_room = scenario.building.rooms[0].name
+        room_log = log.get_room(first_room)
+
+        t_supplies = [curve.t_supply(rec.T_out) for rec in room_log]
+        assert min(t_supplies) >= 25.0, (
+            f"min T_supply={min(t_supplies):.2f} C below min-clamp 25 C"
+        )
+        assert max(t_supplies) <= 55.0 + 1e-9, (
+            f"max T_supply={max(t_supplies):.2f} C above max-clamp 55 C"
+        )
+
+    def test_t_supply_monotonic_with_cold(self) -> None:
+        """T_supply monotonically rises as T_out drops and equals base at warm."""
+        scenario = cold_snap_weather_comp()
+        curve = _curve(scenario)
+
+        assert curve.t_supply(-15.0) > curve.t_supply(0.0) >= curve.t_supply(5.0)
+        assert curve.t_supply(5.0) == pytest.approx(35.0)
+        assert curve.t_supply(-15.0) == pytest.approx(41.0)
+
+    def test_t_supply_plot_generated(
+        self,
+        run_scenario: Callable[
+            [SimScenario, int | None], tuple[SimulationLog, SimMetrics]
+        ],
+        plot_output_dir: Path,
+    ) -> None:
+        """Generate a 2-panel PNG of T_out and T_supply over the simulation."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        scenario = cold_snap_weather_comp()
+        log, _ = run_scenario(scenario, None)
+
+        curve = _curve(scenario)
+        first_room = scenario.building.rooms[0].name
+        room_log = log.get_room(first_room)
+
+        times = [rec.t for rec in room_log]
+        t_outs = [rec.T_out for rec in room_log]
+        t_supplies = [curve.t_supply(rec.T_out) for rec in room_log]
+
+        fig, axes = plt.subplots(2, 1, figsize=(12, 6), sharex=True)
+        axes[0].plot(times, t_outs, label="T_out", color="tab:blue")
+        axes[0].set_ylabel("T_out [degC]")
+        axes[0].legend(loc="upper right")
+
+        axes[1].plot(times, t_supplies, label="T_supply", color="tab:red")
+        axes[1].axhline(25.0, color="tab:gray", linestyle="--", label="min=25")
+        axes[1].axhline(55.0, color="tab:gray", linestyle=":", label="max=55")
+        axes[1].set_ylabel("T_supply [degC]")
+        axes[1].set_xlabel("Time [min]")
+        axes[1].legend(loc="upper right")
+
+        fig.suptitle("cold_snap_weather_comp / T_out vs T_supply")
+        fig.tight_layout()
+
+        out_path = plot_output_dir / "cold_snap_weather_comp_t_supply.png"
+        fig.savefig(str(out_path), dpi=100)
+        plt.close(fig)
+
+        assert out_path.exists(), f"plot not created at {out_path}"
+        assert out_path.stat().st_size > 0, f"plot is empty: {out_path}"

--- a/tests/simulation/test_scenarios.py
+++ b/tests/simulation/test_scenarios.py
@@ -41,6 +41,7 @@ FAST_SCENARIOS: list[str] = [
     "extreme_cold",
     "rapid_warming",
     "cwu_heavy",
+    "cold_snap_weather_comp",
 ]
 """Short-duration scenarios (24h-48h) for regular CI runs."""
 

--- a/tests/unit/test_scenarios.py
+++ b/tests/unit/test_scenarios.py
@@ -48,9 +48,9 @@ class TestScenarioConstruction:
         """SCENARIO_LIBRARY contains at least 8 single scenarios."""
         assert len(SCENARIO_LIBRARY) >= 8
 
-    def test_exactly_17_single_scenarios(self) -> None:
-        """SCENARIO_LIBRARY has exactly 17 entries."""
-        assert len(SCENARIO_LIBRARY) == 17
+    def test_exactly_18_single_scenarios(self) -> None:
+        """SCENARIO_LIBRARY has exactly 18 entries."""
+        assert len(SCENARIO_LIBRARY) == 18
 
     def test_exactly_2_parametric_sweeps(self) -> None:
         """PARAMETRIC_SWEEPS has exactly 2 entries."""

--- a/tests/unit/test_weather_comp.py
+++ b/tests/unit/test_weather_comp.py
@@ -618,6 +618,9 @@ class TestSerialization:
 # ===========================================================================
 
 
+_SCENARIOS_WITH_CURVES = {"cold_snap_weather_comp"}
+
+
 @pytest.mark.unit
 class TestSimScenarioBackwardCompatibility:
     """Tests that SimScenario accepts weather_comp/cooling_comp optionally."""
@@ -684,14 +687,15 @@ class TestSimScenarioBackwardCompatibility:
     def test_all_library_scenarios_still_construct(self, name: str) -> None:
         """Every scenario in SCENARIO_LIBRARY constructs without error.
 
-        This verifies backward compatibility — existing scenarios that do
-        not provide weather_comp / cooling_comp default to None.
+        Existing scenarios default weather_comp / cooling_comp to None;
+        scenarios that intentionally use a curve are tracked explicitly.
         """
         factory = SCENARIO_LIBRARY[name]
         scenario = factory()
         assert isinstance(scenario, SimScenario)
-        assert scenario.weather_comp is None
-        assert scenario.cooling_comp is None
+        if name not in _SCENARIOS_WITH_CURVES:
+            assert scenario.weather_comp is None
+            assert scenario.cooling_comp is None
 
 
 # ===========================================================================


### PR DESCRIPTION
Closes #147

## Summary
Adds a new simulation scenario `cold_snap_weather_comp` that mirrors the existing `cold_snap` weather (step 0 °C → -15 °C at t=1440 min) but runs for 48 h on `modern_bungalow` (7 kW HP, 8 rooms) with a realistic HP heating curve: `WeatherCompCurve(base=35, slope=0.4, neutral=0, max=55, min=25)` — yielding ~41 °C supply at the -15 °C peak. Registered in `__all__` and `SCENARIO_LIBRARY` (alphabetical) and added to `FAST_SCENARIOS`. Dedicated test module validates comfort, floor safety, T_supply peak/clamps/monotonicity, and generates a 2-panel T_supply plot.

The Round 2 commit gates the pre-existing `tests/unit/test_weather_comp.py::test_all_library_scenarios_still_construct` backward-compat assertion behind `_SCENARIOS_WITH_CURVES = {"cold_snap_weather_comp"}` so scenarios intentionally using a curve are explicitly exempted while all others still assert `weather_comp is None`.

## Test plan
- [x] `pytest tests/simulation/test_cold_snap_weather_comp.py -v -m simulation` — 7 passed
- [x] `pytest tests/simulation/test_scenarios.py -v -m simulation -k cold_snap_weather_comp` — 4 passed
- [x] `pytest tests/unit/test_weather_comp.py -v -m unit` — 68 passed (Round 2 regression)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy pumpahead/ tests/simulation/test_cold_snap_weather_comp.py tests/unit/test_weather_comp.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)