### PR TITLE
Issue #166: Remove continue-on-error from simulation CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
   simulation-tests:
     name: Simulation tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,12 @@ pip install -e ".[dev]"
 
 ### Running Tests
 
+The test suite uses three pytest markers:
+
+- `@pytest.mark.unit` -- fast, isolated tests (run by default in the `Unit tests` CI job).
+- `@pytest.mark.simulation` -- scenario-based tests that exercise the building simulator end-to-end. These run in the `Simulation tests` CI job and **block merge on failure**.
+- `@pytest.mark.slow` -- longer-running scenarios (capped at a 3-day horizon). These still run in CI as part of the simulation job; locally you can skip them with `-m "not slow"` for a faster feedback loop.
+
 ```bash
 # All tests
 pytest
@@ -241,9 +247,14 @@ pytest tests/unit/
 # Simulation scenarios (slower, includes full-year runs)
 pytest tests/simulation/
 
+# Simulation scenarios (fast subset, skip 3-day slow tier)
+pytest tests/simulation/ -m "simulation and not slow"
+
 # With coverage
 pytest --cov=pumpahead --cov-report=html
 ```
+
+The CI `Simulation tests` job is a hard gate -- any simulation regression blocks merge to `master`.
 
 ### Code Quality
 


### PR DESCRIPTION
Closes #166

## Summary
- Remove `continue-on-error: true` from the `simulation-tests` job in `.github/workflows/ci.yml` so simulation regressions now hard-block merges to `master`.
- Document the `unit` / `simulation` / `slow` pytest markers in the README "Running Tests" section and show how to skip the slow tier locally (`-m "simulation and not slow"`).
- State explicitly that the `Simulation tests` CI job is a hard gate.

## Verification
- `grep -r "continue-on-error" .github/` → no matches
- `pytest tests/simulation/ -m simulation --tb=long` → 88 passed in 55s locally
- `ruff check` + `ruff format --check` clean